### PR TITLE
docs: update homepage, bugs, repository urls + description

### DIFF
--- a/packages/fragments/package.json
+++ b/packages/fragments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thatopen/fragments",
-  "description": "Collection of core functionalities to author BIM apps.",
+  "description": "Fragments utilities.",
   "version": "2.0.0-alpha.1",
   "author": "That Open Company",
   "contributors": [
@@ -9,9 +9,9 @@
     "Harry Collin (https://github.com/harrycollin)"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/ThatOpen/engine_components/tree/main/packages/components#readme",
+  "homepage": "https://docs.thatopen.com/",
   "bugs": {
-    "url": "https://github.com/ThatOpen/engine_components/issues"
+    "url": "https://github.com/ThatOpen/engine_fragment/issues"
   },
   "type": "module",
   "main": "dist/index.cjs",
@@ -22,7 +22,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ThatOpen/engine_components/tree/main/packages/components.git"
+    "url": "https://github.com/ThatOpen/engine_fragment.git",
+    "directory": "packages/fragments"
   },
   "packageManager": "yarn@3.2.1",
   "scripts": {


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->

Repository, Homepage and Bugs urls in the fragments package currently point to `engine_components`, which is incorrect. This PR updates the urls to the `engine_fragments` repo and updates the package description.

structure of `repository` field was slightly changed to adhere to npm guidelines: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository

### Additional context

confirmed with @agviegas 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
