### PR TITLE
fix(perf): improve performance of getLocalIdsByGuids

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-properties-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-properties-controller.ts
@@ -155,13 +155,19 @@ export class VirtualPropertiesController {
   }
 
   getLocalIdsByGuids(guids: string[]) {
-    const localIds: (number | null)[] = guids.map(() => null);
+    const localIds: (number | null)[] = new Array(guids.length).fill(null);
+
+    const guidToIndexMap = new Map();
+    guids.forEach((guid, index) => {
+      guidToIndexMap.set(guid, index);
+    });
+
     let found = 0;
     const guidCount = this._model.guidsLength();
     for (let i = 0; i < guidCount; i++) {
       const guid = this._model.guids(i);
-      const guidIndex = guids.indexOf(guid);
-      if (guidIndex === -1) {
+      const guidIndex = guidToIndexMap.get(guid);
+      if (guidIndex === undefined) {
         continue;
       }
       localIds[guidIndex] = this._model.guidsItems(i);


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

`getLocalIdsByGuids` was taking more than 10 minutes (I didn't wait longer) with tens of thousands of guids.
The reason was `const guidIndex = guids.indexOf(guid);` called 100 000 times, looping over 100 000 guids every time.



### Additional context
The same improvement could be made in other methods using `indexOf` on big arrays in loops.
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
