### PR TITLE
fix: handle double sided materials in the three.js model

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/model/material-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/material-manager.ts
@@ -11,6 +11,7 @@ import {
 import { CRC } from "../utils";
 import { LodMaterial } from "../lod";
 import { DataMap } from "../../../Utils";
+import { RenderedFaces } from "../../../Schema";
 
 export class MaterialManager {
   readonly list = new DataMap<number, BIMMaterial>();
@@ -157,6 +158,7 @@ export class MaterialManager {
         transparent: data.opacity < 1,
         opacity: data.opacity,
         userData: { customId: data.customId },
+        side: (data.renderedFaces === RenderedFaces.ONE ? THREE.FrontSide : THREE.DoubleSide),
       });
     } else if (objectClass === ObjectClass.LINE) {
       material = this.newLODMaterial(


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

The `RenderedFaces` material attribute was not used during material conversion to three.js. I've added a code that handles this parameter as well.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
