### PR TITLE
fix(fragments): Project not compiling (in Angular) due to missing `Sample` type

### DIFF
--- a/packages/fragments/vite.config.ts
+++ b/packages/fragments/vite.config.ts
@@ -73,7 +73,6 @@ export default defineConfig({
       rollupTypes: true,
       exclude: [
         "./src/**/example.ts",
-        "./src/**/sample.ts",
         "./src/**/*.test.ts",
       ],
       // afterBuild: generateTSNamespace,


### PR DESCRIPTION
### Description
The Flatbuffers schema contains a definition for type **Sample**. This type, which is used in **Meshes**, should be exported to the production bundle. Unfortunately, this is not the case. The Vite configuration contains an exclude for files called **sample.ts** - just like the Flatbuffers schema type **Sample** is called. This results in the project not compiling (in Angular), because the **index.d.ts** attempts to include the **Sample** type from its original location, where it obviously is no longer present.

Fixes #54 

### Additional context
This pull request removes the exclusion entirely. The other files called **sample.ts** are not exported, so they are not included in the final bundle.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
