### PR TITLE
Add support for parsing unit definitions from IFC models

### DIFF
--- a/packages/fragments/src/Importers/IfcImporter/index.ts
+++ b/packages/fragments/src/Importers/IfcImporter/index.ts
@@ -52,6 +52,7 @@ export class IfcImporter {
   classes = {
     elements: new DataSet<number>([...ifcClasses.elements]),
     abstract: new DataSet<number>([
+      ...ifcClasses.units,
       ...ifcClasses.base,
       ...ifcClasses.materials,
       ...ifcClasses.properties,

--- a/packages/fragments/src/Importers/IfcImporter/src/classes.ts
+++ b/packages/fragments/src/Importers/IfcImporter/src/classes.ts
@@ -1,6 +1,13 @@
 import * as WEBIFC from "web-ifc";
 
 export const ifcClasses = {
+  units: new Set([
+    WEBIFC.IFCUNITASSIGNMENT,
+    WEBIFC.IFCSIUNIT,
+    WEBIFC.IFCNAMEDUNIT,
+    WEBIFC.IFCDERIVEDUNIT,
+    WEBIFC.IFCMONETARYUNIT,
+  ]),
   base: new Set([
     WEBIFC.IFCPROJECT,
     WEBIFC.IFCSITE,


### PR DESCRIPTION
### Description

This PR adds support for extracting unit information from the model. The importer now parses unit definitions by handling the following IFC entities via WEBIFC: IfcUnitAssignment, IfcSIUnit, IfcNamedUnit, IfcDerivedUnit, and IfcMonetaryUnit. The corresponding classes have been added to classes.ts.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other
