### PR TITLE
fix(ifc-importer): exclude boolean from attribute serialization process

### DIFF
--- a/packages/fragments/src/Importers/IfcImporter/src/properties/property-processor.ts
+++ b/packages/fragments/src/Importers/IfcImporter/src/properties/property-processor.ts
@@ -61,7 +61,7 @@ export class IfcPropertyProcessor {
   constructor(
     private _serializer: IfcImporter,
     private _builder: Builder,
-  ) {}
+  ) { }
 
   async process(data: PropertiesProcessData) {
     // Open the IFC
@@ -349,7 +349,7 @@ export class IfcPropertyProcessor {
 
     let index = 0;
     for (const [attrName, attrValue] of Object.entries(attrs)) {
-      if (typeof attrValue === "number") continue;
+      if (typeof attrValue === "number" || typeof attrValue === "boolean") continue;
       if (
         this._serializer.attributesToExclude.has(attrName) ||
         attrValue === null ||


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

The fix to the boolean attribute serialization [issue](https://github.com/ThatOpen/engine_fragment/issues/94)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
