### PR TITLE
docs: Incomplete sentence (extra "and") in the tutorial HelloWorldSchema

### DIFF
--- a/packages/fragments/src/Importers/IfcImporter/examples/HelloWorldSchema/example.ts
+++ b/packages/fragments/src/Importers/IfcImporter/examples/HelloWorldSchema/example.ts
@@ -2,7 +2,7 @@
   ## Hello World Schema 📋
   ---
   
-  In this demo we will create a simple app that allows us to navigate the Fragments schema of IFC STEP files. This is not something you will usually need to do in your apps, but it will serve as a demonstration and
+  In this demo we will create a simple app that allows us to navigate the Fragments schema of IFC STEP files. This is not something you will usually need to do in your apps, but it will serve as a demonstration
   
   ### 🖖 Importing our Libraries
   First things first, let's install all necessary dependencies to make this little example work:


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Removed extra word "and" in the tutorial description.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

The tutorial sentence ends with an extra "and". This is a short PR that cleans up the wording and improves readability.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
