### PR TITLE
fix: correct raycasting frustum calculation for orthographic cameras

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/model/raycast-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/raycast-manager.ts
@@ -154,9 +154,14 @@ export class RaycastManager {
   }
 
   private setEnds(camera: THREE.Camera) {
-    this._n.constant = camera.position.length();
+    if (camera instanceof THREE.OrthographicCamera) {
+      this._n.constant = camera.near;
+      this._f.constant = camera.far;
+    } else {
+      this._n.constant = camera.position.length();
+      this._f.constant = Infinity;
+    }
     this._f.normal = this._n.normal;
-    this._f.constant = Infinity;
   }
 
   private screenToCast(p: Point, element: any, result = new THREE.Vector2()) {


### PR DESCRIPTION

### Description

 - Fixes element selection/highlighting not working in 2D plan view                                                                                            
  - The `setEnds` method now correctly handles orthographic cameras by using their `near`/`far` properties instead of position-based calculation
 
### Additional context

Previously when in a 2d plan view the hoverer and highlighter effects would not show.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ X ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other


### Example

<img width="600" height="350" alt="Screenshot 2025-12-18 at 7 14 40 PM" src="https://github.com/user-attachments/assets/5e0805e4-a9ce-48f1-b2d6-8feabdbc98a7" />
