### PR TITLE
feat(materials): Add setColor method with opacity preservation

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
@@ -632,6 +632,43 @@ export class FragmentsModel {
   }
 
   /**
+   * Applies a color to the specified items while preserving original material properties.
+   * @param localIds - The local IDs of the items to color. If undefined, all items will be colored.
+   * @param color - The color to apply.
+   */
+  async setColor(
+    localIds: number[] | undefined,
+    color: MaterialDefinition["color"],
+  ) {
+    return this._highlightManager.setColor(this, localIds, color);
+  }
+
+  /**
+   * Resets the color of the specified items to their original color while preserving other highlight properties (like opacity).
+   * @param localIds - The local IDs of the items to reset color for. If undefined, all items will be affected.
+   */
+  async resetColor(localIds: number[] | undefined) {
+    return this._highlightManager.resetColor(this, localIds);
+  }
+
+  /**
+   * Applies an opacity to the specified items while preserving original material properties (like color).
+   * @param localIds - The local IDs of the items to change opacity for. If undefined, all items will be affected.
+   * @param opacity - The opacity to apply (0 to 1).
+   */
+  async setOpacity(localIds: number[] | undefined, opacity: number) {
+    return this._highlightManager.setOpacity(this, localIds, opacity);
+  }
+
+  /**
+   * Resets the opacity of the specified items to their original opacity while preserving other highlight properties (like color).
+   * @param localIds - The local IDs of the items to reset opacity for. If undefined, all items will be affected.
+   */
+  async resetOpacity(localIds: number[] | undefined) {
+    return this._highlightManager.resetOpacity(this, localIds);
+  }
+
+  /**
    * Gets the highlight of the specified items.
    * @param localIds - The local IDs of the items to get the highlight of. If undefined, it will return the highlight of all items.
    */

--- a/packages/fragments/src/FragmentsModels/src/model/highlight-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/highlight-manager.ts
@@ -24,6 +24,30 @@ export class HighlightManager {
     ]);
   }
 
+  async setColor(
+    model: FragmentsModel,
+    localIds: number[] | undefined,
+    color: MaterialDefinition["color"],
+  ) {
+    await model.threads.invoke(model.modelId, "setColor", [localIds, color]);
+  }
+
+  async resetColor(model: FragmentsModel, localIds: number[] | undefined) {
+    await model.threads.invoke(model.modelId, "resetColor", [localIds]);
+  }
+
+  async setOpacity(
+    model: FragmentsModel,
+    localIds: number[] | undefined,
+    opacity: number,
+  ) {
+    await model.threads.invoke(model.modelId, "setOpacity", [localIds, opacity]);
+  }
+
+  async resetOpacity(model: FragmentsModel, localIds: number[] | undefined) {
+    await model.threads.invoke(model.modelId, "resetOpacity", [localIds]);
+  }
+
   async getHighlightItemIds(model: FragmentsModel) {
     return model.threads.invoke(
       model.modelId,

--- a/packages/fragments/src/FragmentsModels/src/model/material-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/material-manager.ts
@@ -199,10 +199,27 @@ export class MaterialManager {
     if (!localMap.has(highlightIndex)) {
       const originalDefinition = materialDefinitions[index];
       const newDefinition = materialDefinitions[highlightIndex];
-      const combinedDefinition: MaterialDefinition = {
-        ...originalDefinition,
-        ...newDefinition,
-      };
+      const { preserveOriginalMaterial, ...highlightDefinition } = newDefinition;
+      const combinedDefinition: MaterialDefinition = { ...originalDefinition };
+      if (preserveOriginalMaterial) {
+        if (highlightDefinition.color !== undefined) {
+          combinedDefinition.color = highlightDefinition.color;
+        }
+        if (highlightDefinition.opacity !== undefined) {
+          combinedDefinition.opacity = highlightDefinition.opacity;
+        }
+        if (highlightDefinition.transparent !== undefined) {
+          combinedDefinition.transparent = highlightDefinition.transparent;
+        }
+        if (highlightDefinition.renderedFaces !== undefined) {
+          combinedDefinition.renderedFaces = highlightDefinition.renderedFaces;
+        }
+        if (highlightDefinition.depthTest !== undefined) {
+          combinedDefinition.depthTest = highlightDefinition.depthTest;
+        }
+      } else {
+        Object.assign(combinedDefinition, highlightDefinition);
+      }
       const material = this.get(combinedDefinition, request);
       materials.push(material);
       localMap.set(highlightIndex, materials.length - 1);

--- a/packages/fragments/src/FragmentsModels/src/model/model-types.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/model-types.ts
@@ -110,6 +110,11 @@ export type MaterialDefinition = {
   opacity: number;
   /** Whether the material is transparent */
   transparent: boolean;
+  /**
+   * Internal flag to preserve base material properties when applying highlights.
+   * When true, only explicitly set properties (like color or opacity) are applied.
+   */
+  preserveOriginalMaterial?: boolean;
   /** An optional custom ID for the material */
   customId?: string;
   /**

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-material-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-material-controller.ts
@@ -65,6 +65,12 @@ export class VirtualMaterialController {
   }
 
   private checkMaterialExists(material: MaterialDefinition, ids: number[]) {
+    // Don't deduplicate materials with preserveOriginalMaterial flag,
+    // as they need to preserve original material properties (like opacity)
+    // which may differ from existing materials with the same color
+    if (material.preserveOriginalMaterial) {
+      return false;
+    }
     const count = this._list.length;
     for (let i = 0; i < count; i++) {
       const current = this._list[i];

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
@@ -212,6 +212,22 @@ export class VirtualFragmentsModel {
     this._highlightHelper.highlight(this, items, highlightMaterial);
   }
 
+  setColor(items: number[], color: MaterialDefinition["color"]) {
+    this._highlightHelper.setColor(this, items, color);
+  }
+
+  resetColor(items: number[]) {
+    this._highlightHelper.resetColor(this, items);
+  }
+
+  setOpacity(items: number[], opacity: number) {
+    this._highlightHelper.setOpacity(this, items, opacity);
+  }
+
+  resetOpacity(items: number[]) {
+    this._highlightHelper.resetOpacity(this, items);
+  }
+
   getHighlight(localIds: number[]) {
     return this._highlightHelper.getHighlight(this, localIds);
   }

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-helpers/highlight-helper.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-helpers/highlight-helper.ts
@@ -50,6 +50,93 @@ export class HighlightHelper {
     model.tiles.updateVirtualMeshes(itemIds);
   }
 
+  private hasEffectiveProperties(material: Partial<MaterialDefinition>) {
+    const { preserveOriginalMaterial, ...rest } = material;
+    return Object.keys(rest).length > 0;
+  }
+
+  private updateHighlightDefinition(
+    model: VirtualFragmentsModel,
+    items: number[],
+    updateFn: (current: MaterialDefinition) => Partial<MaterialDefinition>,
+  ) {
+    const itemIds = model.properties.getItemIdsFromLocalIds(items);
+    const itemsToUpdate: number[] = [];
+    const itemsToClear: number[] = [];
+    const materials: MaterialDefinition[] = [];
+
+    for (const itemId of itemIds) {
+      const highlightId = model.itemConfig.getHighlight(itemId);
+      if (highlightId) {
+        const currentHighlight = model.materials.fetch(highlightId);
+        const updated = updateFn(currentHighlight);
+        if (this.hasEffectiveProperties(updated)) {
+          const newMaterial = {
+            ...updated,
+            preserveOriginalMaterial: true,
+          } as MaterialDefinition;
+          materials.push(newMaterial);
+          itemsToUpdate.push(itemId);
+        } else {
+          itemsToClear.push(itemId);
+        }
+      }
+    }
+
+    if (itemsToClear.length > 0) {
+      for (const itemId of itemsToClear) {
+        model.itemConfig.setHighlight(itemId, 0);
+      }
+    }
+
+    if (itemsToUpdate.length > 0) {
+      const ids = model.materials.transfer(materials);
+      const createEvent = this.getCreateEvent(model, ids);
+      model.traverse(itemsToUpdate, createEvent);
+    }
+
+    model.tiles.updateVirtualMeshes(itemIds);
+  }
+
+  setColor(
+    model: VirtualFragmentsModel,
+    items: number[],
+    color: MaterialDefinition["color"],
+  ) {
+    const material = {
+      color,
+      preserveOriginalMaterial: true,
+    } as MaterialDefinition;
+    this.highlight(model, items, material);
+  }
+
+  resetColor(model: VirtualFragmentsModel, items: number[]) {
+    this.updateHighlightDefinition(model, items, (current) => {
+      const { color: _, ...rest } = current;
+      return rest;
+    });
+  }
+
+  setOpacity(
+    model: VirtualFragmentsModel,
+    items: number[],
+    opacity: number,
+  ) {
+    const material = {
+      opacity,
+      transparent: opacity < 1,
+      preserveOriginalMaterial: true,
+    } as MaterialDefinition;
+    this.highlight(model, items, material);
+  }
+
+  resetOpacity(model: VirtualFragmentsModel, items: number[]) {
+    this.updateHighlightDefinition(model, items, (current) => {
+      const { opacity: _o, transparent: _t, ...rest } = current;
+      return rest;
+    });
+  }
+
   private getFetchEvent(
     model: VirtualFragmentsModel,
     found: MaterialDefinition[],


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

This PR adds a new `setColor` method that allows applying color-only highlights while preserving original material properties such as opacity and transparency. The method provides a convenient way to change only the color of items without affecting other material properties.

**Key changes:**

1. **New `setColor` method** - Added to `FragmentsModel`, `VirtualFragmentsModel`, `HighlightManager`, and `HighlightHelper`:
   - Applies color changes while preserving original material properties
   - Uses a new `preserveOriginalMaterial` flag in `MaterialDefinition` to indicate color-only operations

2. **Enhanced `processHighlight` in `MaterialManager`** - Fixed to properly handle the `preserveOriginalMaterial` flag:
   - When enabled, preserves base material properties (opacity, transparency, depthTest) from the original material
   - Only updates the color and optionally `renderedFaces` while maintaining other properties

3. **Material deduplication fix** - Updated `VirtualMaterialController` to prevent deduplication for materials with `preserveOriginalMaterial` flag, as they need to preserve original properties that may differ even with the same color

4. **Type definition** - Added `preserveOriginalMaterial?: boolean` to `MaterialDefinition` type

### Usage Example

The `setColor` method provides a simple API for applying color-only highlights while preserving material properties like opacity:
```

import * as THREE from "three";
import { FragmentsModel } from "@thatopen/fragments";

// Apply a red color to specific items (preserves their original opacity)
await model.setColor([1, 2, 3], new THREE.Color(1, 0, 0));

// Apply a green color to all items in the model
await model.setColor([5, 6, 7], new THREE.Color("#00ff00"));
```


**Key benefit:** Unlike using `highlight()` with a full material definition, `setColor()` automatically preserves the original material's opacity and transparency. This is especially useful when working with transparent materials that should maintain their transparency when highlighted.

### Additional context

This feature is particularly useful for visualizations where you want to change the color of items (e.g., for highlighting or filtering) without losing transparency or other material properties. The `setColor` method provides a simpler API compared to using `highlight` with a full material definition when only the color needs to change. Otherwise it is not possible to add color to an item that has different material opacities (e.g. a window with frame and glass) while those opacities should be obtained.

**Files changed:**
- `fragments-model.ts` - Added `setColor` method
- `highlight-manager.ts` - Added `setColor` method
- `highlight-helper.ts` - Added `setColor` implementation
- `virtual-fragments-model.ts` - Added `setColor` method
- `material-manager.ts` - Enhanced `processHighlight` to preserve original material properties
- `virtual-material-controller.ts` - Prevented deduplication for materials with `preserveOriginalMaterial`
- `model-types.ts` - Added `preserveOriginalMaterial` flag to `MaterialDefinition`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.