### PR TITLE
feat(materials): add depthWrite property to MaterialDefinition

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/model/material-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/material-manager.ts
@@ -158,6 +158,7 @@ export class MaterialManager {
         opacity: data.opacity,
         userData: { customId: data.customId, localId: data.localId },
         depthTest: data.depthTest ?? true,
+        depthWrite: data.depthWrite ?? true,
         side: data.renderedFaces === 1 ? THREE.DoubleSide : THREE.FrontSide,
       });
     } else if (objectClass === ObjectClass.LINE) {

--- a/packages/fragments/src/FragmentsModels/src/model/model-types.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/model-types.ts
@@ -113,11 +113,17 @@ export type MaterialDefinition = {
   /** An optional custom ID for the material */
   customId?: string;
   /**
-   * Whether to have depth test enabled when rendering this material. When the depth test is disabled, the depth write
-   * will also be implicitly disabled.
+   * Whether to have depth test enabled when rendering this material.
    * @default true
    */
   depthTest?: boolean;
+
+  /**
+   * Whether to write to the depth buffer. Set to false for transparent objects
+   * that shouldn't occlude other geometry
+   * @default true
+   */
+  depthWrite?: boolean;
 
   /** The local ID of the material */
   localId?: number;


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

This PR adds support for controlling depth buffer writes in material definitions. The new `depthWrite` property allows developers to specify whether a material should write to the depth buffer during rendering.

This is particularly useful for transparent objects that shouldn't occlude other geometry behind them. When `depthWrite` is set to `false`, transparent materials can render correctly without blocking objects that should be visible through them.

**Changes:**
- Added `depthWrite?: boolean` property to `MaterialDefinition` type with default value of `true`
- Implemented `depthWrite` handling in `MaterialManager` when creating materials (defaults to `true` if not specified)
- Added `depthWrite` support in highlight definition merging logic
- Updated documentation to clarify the relationship between `depthTest` and `depthWrite`

### Additional context

This feature complements the existing `depthTest` property and provides finer control over depth buffer operations.

**Files modified:**
- `packages/fragments/src/FragmentsModels/src/model/material-manager.ts`
- `packages/fragments/src/FragmentsModels/src/model/model-types.ts`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.