### PR TITLE
Fix: reset attributesToExclude to ensure all attributes are processed

### DIFF
--- a/packages/fragments/src/Importers/IfcImporter/index.ts
+++ b/packages/fragments/src/Importers/IfcImporter/index.ts
@@ -97,7 +97,7 @@ export class IfcImporter {
       ...ifcClasses.base,
       ...ifcClasses.materials,
       ...ifcClasses.properties,
-      ...ifcClasses.units
+      ...ifcClasses.units,
     ]),
   };
 
@@ -234,6 +234,7 @@ export class IfcImporter {
       }
       this.classes.abstract.add(category);
     }
+    this.attributesToExclude = new Set();
   }
 
   /**


### PR DESCRIPTION
Fix #133 

### Description

When the user calls addAllAttributes(), some attributes are still excluded. This PR clears the exclusion filter to allow full attribute loading (particularly OwnerHistory and ObjectPlacement).

<img width="960" height="1200" alt="image" src="https://github.com/user-attachments/assets/098a56d0-8c6e-480d-aa0d-90e2ffb39605" />


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
