### PR TITLE
fix(ifc-splitter): add  `IFCMECHANICALFASTENER` to elements types

### DIFF
--- a/packages/fragments/src/Utils/ifc-splitter/index.ts
+++ b/packages/fragments/src/Utils/ifc-splitter/index.ts
@@ -149,7 +149,8 @@ const ELEMENT_TYPES: Set<string> = new Set([
   "IFCSHADINGDEVICE",
   "IFCCHIMNEY",
   "IFCGEOGRAPHICELEMENT",
-  "IFCPROXY",
+  "IFCPROXY", 
+  "IFCMECHANICALFASTENER",
 ]);
 
 const SPATIAL_TYPES: Set<string> = new Set([


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

related #174


Adds `IFCMECHANICALFASTENER` to `ELEMENT_TYPES` so that it is included in the output ifc. This fixes the style of the output `IFCMECHANICALFASTENER`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
https://github.com/ThatOpen/engine_fragment/issues/174#issuecomment-4087834386

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
