### PR TITLE
feat: add VirtualMultithreadingConfig to configure delays/thresholds

### DIFF
--- a/packages/fragments/src/FragmentsModels/index.ts
+++ b/packages/fragments/src/FragmentsModels/index.ts
@@ -179,10 +179,10 @@ export class FragmentsModels {
     const virtualModelConfig: VirtualModelConfig = {
       ...options.virtualModelConfig,
       multithreading: {
-        ...options.virtualModelConfig?.multithreading,
         meshConnectionRate: this.settings.meshConnectionRate,
         meshConnectionThreshold: this.settings.meshConnectionThreshold,
         threadUpdaterDelay: this.settings.threadUpdaterDelay,
+        ...options.virtualModelConfig?.multithreading,
       },
     };
 

--- a/packages/fragments/src/FragmentsModels/index.ts
+++ b/packages/fragments/src/FragmentsModels/index.ts
@@ -96,6 +96,12 @@ export class FragmentsModels {
     forceUpdateRate: 200,
     /** Force update buffer time in milliseconds */
     forceUpdateBuffer: 200,
+    /** Interval in milliseconds to flush queued mesh requests from thread to main thread */
+    meshConnectionRate: 64,
+    /** Number of queued mesh requests that triggers an immediate flush */
+    meshConnectionThreshold: 16,
+    /** Delay in milliseconds between worker-side update loops when work is complete */
+    threadUpdaterDelay: 128,
   };
 
   /** Coordinates of the first loaded model, used for coordinate system alignment */
@@ -170,6 +176,16 @@ export class FragmentsModels {
       onProgress?: (event: LoadProgressEvent) => void;
     },
   ) {
+    const virtualModelConfig: VirtualModelConfig = {
+      ...options.virtualModelConfig,
+      multithreading: {
+        ...options.virtualModelConfig?.multithreading,
+        meshConnectionRate: this.settings.meshConnectionRate,
+        meshConnectionThreshold: this.settings.meshConnectionThreshold,
+        threadUpdaterDelay: this.settings.threadUpdaterDelay,
+      },
+    };
+
     const model = new FragmentsModel(
       options.modelId,
       this.models,
@@ -192,7 +208,7 @@ export class FragmentsModels {
 
     try {
       this.models.list.set(model.modelId, model);
-      await model._setup(buffer, options.raw, options.virtualModelConfig);
+      await model._setup(buffer, options.raw, virtualModelConfig);
       if (this.settings.autoCoordinate) {
         const coordinates = await model.getCoordinates();
         if (this.baseCoordinates === null) {

--- a/packages/fragments/src/FragmentsModels/src/edit/edit-helper.ts
+++ b/packages/fragments/src/FragmentsModels/src/edit/edit-helper.ts
@@ -204,10 +204,7 @@ export class EditHelper {
     // disposes the old delta model).
     (deltaModel as any)._frozen = false;
     await deltaModel._refreshView();
-    await this._fragments.models.forceUpdateFinish(
-      this._fragments.settings.forceUpdateRate,
-      this._fragments.settings.forceUpdateBuffer,
-    );
+    await this._fragments.models.forceUpdateFinish();
 
     return deltaModel;
   }

--- a/packages/fragments/src/FragmentsModels/src/edit/edit-helper.ts
+++ b/packages/fragments/src/FragmentsModels/src/edit/edit-helper.ts
@@ -2,6 +2,7 @@ import { FragmentsModel, FragmentsModels } from "../..";
 import * as EDIT from "../../../Utils/edit";
 import { FragmentsConnection } from "../multithreading/fragments-connection";
 import { EditUtils } from "../../../Utils/edit/edit-utils";
+import { VirtualModelConfig } from "../model/model-types";
 
 export class EditHelper {
   private _deltaModels: { [modelId: string]: FragmentsModel[] | null } = {};
@@ -173,9 +174,17 @@ export class EditHelper {
 
     deltaModel.graphicsQuality = this._fragments.settings.graphicsQuality;
 
+    const virtualModelConfig: VirtualModelConfig = {
+      multithreading: {
+        meshConnectionRate: this._fragments.settings.meshConnectionRate,
+        meshConnectionThreshold: this._fragments.settings.meshConnectionThreshold,
+        threadUpdaterDelay: this._fragments.settings.threadUpdaterDelay,
+      },
+    };
+
     try {
       this._fragments.models.list.set(deltaModel.modelId, deltaModel);
-      await deltaModel._setup(buffer, true);
+      await deltaModel._setup(buffer, true, virtualModelConfig);
       parentModel.object.add(deltaModel.object);
     } catch (e) {
       this._fragments.models.list.delete(deltaModel.modelId);
@@ -195,7 +204,10 @@ export class EditHelper {
     // disposes the old delta model).
     (deltaModel as any)._frozen = false;
     await deltaModel._refreshView();
-    await this._fragments.models.forceUpdateFinish();
+    await this._fragments.models.forceUpdateFinish(
+      this._fragments.settings.forceUpdateRate,
+      this._fragments.settings.forceUpdateBuffer,
+    );
 
     return deltaModel;
   }

--- a/packages/fragments/src/FragmentsModels/src/lod/lod-mesh.ts
+++ b/packages/fragments/src/FragmentsModels/src/lod/lod-mesh.ts
@@ -4,8 +4,8 @@ import { LODGeometry } from "./lod-geometry";
 import { LodHelper } from "./lod-helper";
 
 export class LODMesh extends THREE.Mesh {
-  geometry: LODGeometry;
-  material: LodMaterial[];
+  declare geometry: LODGeometry;
+  declare material: LodMaterial[];
 
   constructor(geometry: LODGeometry, material: LodMaterial[]) {
     super(geometry, material);

--- a/packages/fragments/src/FragmentsModels/src/model/model-types.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/model-types.ts
@@ -502,7 +502,7 @@ export interface VirtualPropertiesConfig {
 export interface VirtualMultithreadingConfig {
   /** Interval in milliseconds to flush queued mesh requests */
   meshConnectionRate?: number;
-  /** Queue length that triggers immediate mesh request flushing */
+  /** Queue length that, when exceeded, triggers immediate mesh request flushing */
   meshConnectionThreshold?: number;
   /** Delay in milliseconds between worker-side update loop iterations */
   threadUpdaterDelay?: number;

--- a/packages/fragments/src/FragmentsModels/src/model/model-types.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/model-types.ts
@@ -497,11 +497,25 @@ export interface VirtualPropertiesConfig {
 }
 
 /**
+ * Interface representing multithreading timing configuration for virtual models.
+ */
+export interface VirtualMultithreadingConfig {
+  /** Interval in milliseconds to flush queued mesh requests */
+  meshConnectionRate?: number;
+  /** Queue length that triggers immediate mesh request flushing */
+  meshConnectionThreshold?: number;
+  /** Delay in milliseconds between worker-side update loop iterations */
+  threadUpdaterDelay?: number;
+}
+
+/**
  * Interface representing the configuration for a virtual model.
  */
 export interface VirtualModelConfig {
   /** Optional properties configuration for the virtual model */
   properties?: VirtualPropertiesConfig;
+  /** Optional multithreading timing configuration for the virtual model */
+  multithreading?: VirtualMultithreadingConfig;
 }
 
 /**

--- a/packages/fragments/src/FragmentsModels/src/multithreading/mesh-connection.ts
+++ b/packages/fragments/src/FragmentsModels/src/multithreading/mesh-connection.ts
@@ -1,5 +1,6 @@
 import { Connection } from "./connection";
 import { MultithreadingHelper } from "./multithreading-helper";
+import { VirtualMultithreadingConfig } from "../model/model-types";
 
 export class MeshConnection {
   private _rate = 64;
@@ -13,9 +14,16 @@ export class MeshConnection {
     return this._list.length > this._threshold;
   }
 
-  constructor(modelId: string, connection: Connection) {
+  constructor(
+    modelId: string,
+    connection: Connection,
+    multithreading?: VirtualMultithreadingConfig,
+  ) {
     this._modelId = modelId;
     this._connection = connection;
+    this._rate = multithreading?.meshConnectionRate ?? this._rate;
+    this._threshold =
+      multithreading?.meshConnectionThreshold ?? this._threshold;
     this._updater = MultithreadingHelper.newUpdater(this.refresh, this._rate);
   }
 

--- a/packages/fragments/src/FragmentsModels/src/multithreading/mesh-connection.ts
+++ b/packages/fragments/src/FragmentsModels/src/multithreading/mesh-connection.ts
@@ -21,9 +21,16 @@ export class MeshConnection {
   ) {
     this._modelId = modelId;
     this._connection = connection;
-    this._rate = multithreading?.meshConnectionRate ?? this._rate;
-    this._threshold =
-      multithreading?.meshConnectionThreshold ?? this._threshold;
+    const configuredRate = multithreading?.meshConnectionRate;
+    if (Number.isFinite(configuredRate) && configuredRate >= 0) {
+      this._rate = configuredRate;
+    }
+
+    const configuredThreshold = multithreading?.meshConnectionThreshold;
+    if (Number.isFinite(configuredThreshold) && configuredThreshold >= 0) {
+      this._threshold = configuredThreshold;
+    }
+
     this._updater = MultithreadingHelper.newUpdater(this.refresh, this._rate);
   }
 

--- a/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-model-creator.ts
+++ b/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-model-creator.ts
@@ -26,6 +26,10 @@ export class ThreadModelCreator extends ThreadController {
       notify("decompressing", 1);
       throwIfAborted();
 
+      this.thread.controllerManager.updater.setUpdateDelay(
+        input.config?.multithreading?.threadUpdaterDelay,
+      );
+
       const model = await this.createModel(input, notify, throwIfAborted);
       this.finalize(input, model);
 

--- a/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-model-creator.ts
+++ b/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-model-creator.ts
@@ -26,6 +26,8 @@ export class ThreadModelCreator extends ThreadController {
       notify("decompressing", 1);
       throwIfAborted();
 
+      // The updater is shared by the whole worker, so the latest loaded model
+      // controls the delay for every model assigned to this worker.
       this.thread.controllerManager.updater.setUpdateDelay(
         input.config?.multithreading?.threadUpdaterDelay,
       );

--- a/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-updater.ts
+++ b/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-updater.ts
@@ -16,7 +16,7 @@ export class ThreadUpdater {
   }
 
   setUpdateDelay(delay?: number) {
-    if (typeof delay !== "number" || delay < 0) {
+    if (typeof delay !== "number" || !Number.isFinite(delay) || delay < 0) {
       return;
     }
     this._updateDelay = delay;

--- a/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-updater.ts
+++ b/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-updater.ts
@@ -3,7 +3,7 @@ import { FragmentsThread } from "../fragments-thread";
 export class ThreadUpdater {
   private readonly _thread: FragmentsThread;
   private readonly _updateThreshold = 16;
-  private readonly _updateDelay = 128;
+  private _updateDelay = 128;
 
   constructor(thread: FragmentsThread) {
     this._thread = thread;
@@ -13,6 +13,13 @@ export class ThreadUpdater {
       setTimeout(updateAll, delay);
     };
     updateAll();
+  }
+
+  setUpdateDelay(delay?: number) {
+    if (typeof delay !== "number" || delay < 0) {
+      return;
+    }
+    this._updateDelay = delay;
   }
 
   private updateAllModels() {

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-tiles-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-tiles-controller.ts
@@ -15,6 +15,7 @@ import {
   TileRequestClass,
   SnappingClass,
   LodMode,
+  VirtualMultithreadingConfig,
 } from "../../model/model-types";
 import { VirtualBoxController } from "../../bounding-boxes";
 import {
@@ -44,6 +45,7 @@ type VirtualMeshes = Map<RepresentationClass, VirtualMeshManager>;
 export type VirtualTileData = {
   modelId: string;
   connection: Connection;
+  multithreading?: VirtualMultithreadingConfig;
   model: Model;
   boxes: VirtualBoxController;
   items: ItemConfigController;
@@ -140,7 +142,11 @@ export class VirtualTilesController {
     this._boxes = data.boxes;
     this._items = data.items;
     this._materials = data.materials;
-    this._meshConnection = new MeshConnection(data.modelId, data.connection);
+    this._meshConnection = new MeshConnection(
+      data.modelId,
+      data.connection,
+      data.multithreading,
+    );
     this.meshes = data.model.meshes() as Meshes;
     this._sampleAmount = this.meshes.samplesLength();
     this._samples = new ItemConfigController(this._sampleAmount);

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
@@ -741,6 +741,7 @@ export class VirtualFragmentsModel {
     return new VirtualTilesController({
       modelId: this._modelId,
       connection: this._connection,
+      multithreading: this._config.multithreading,
       model: this.data,
       boxes: this.boxes,
       items: this.itemConfig,

--- a/resources/worker.mjs
+++ b/resources/worker.mjs
@@ -34,7 +34,7 @@ var __privateMethod = (obj, member, method) => {
   __accessCheck(obj, member, "access private method");
   return method;
 };
-var _a, _constructing, _max, _maxSize, _dispose, _onInsert, _disposeAfter, _fetchMethod, _memoMethod, _size, _calculatedSize, _keyMap, _keyList, _valList, _next, _prev, _head, _tail, _free, _disposed, _sizes, _starts, _ttls, _hasDispose, _hasFetchMethod, _hasDisposeAfter, _hasOnInsert, _initializeTTLTracking, initializeTTLTracking_fn, _updateItemAge, _statusTTL, _setItemTTL, _isStale, _initializeSizeTracking, initializeSizeTracking_fn, _removeItemSize, _addItemSize, _requireSize, _indexes, indexes_fn, _rindexes, rindexes_fn, _isValidIndex, isValidIndex_fn, _b, _evict, evict_fn, _backgroundFetch, backgroundFetch_fn, _isBackgroundFetch, isBackgroundFetch_fn, _connect, connect_fn, _moveToTail, moveToTail_fn, _delete, delete_fn, _clear, clear_fn, _c;
+var _a, _constructing, _max, _maxSize, _dispose, _onInsert, _disposeAfter, _fetchMethod, _memoMethod, _size, _calculatedSize, _keyMap, _keyList, _valList, _next, _prev, _head, _tail, _free, _disposed, _sizes, _starts, _ttls, _hasDispose, _hasFetchMethod, _hasDisposeAfter, _hasOnInsert, _initializeTTLTracking, initializeTTLTracking_fn, _updateItemAge, _statusTTL, _setItemTTL, _isStale, _initializeSizeTracking, initializeSizeTracking_fn, _removeItemSize, _addItemSize, _requireSize, _indexes, indexes_fn, _rindexes, rindexes_fn, _isValidIndex, isValidIndex_fn, _b, _evict, evict_fn, _backgroundFetch, backgroundFetch_fn, _isBackgroundFetch, isBackgroundFetch_fn, _connect, connect_fn, _moveToTail, moveToTail_fn, _delete, delete_fn, _clear, clear_fn;
 class ConnectionHandlers {
   constructor() {
     __publicField(this, "_list", /* @__PURE__ */ new Map());
@@ -23033,10 +23033,10 @@ function earcut$1(data, holeIndices, dim = 2) {
   if (hasHoles)
     outerNode = eliminateHoles$1(data, holeIndices, outerNode, dim);
   if (data.length > 80 * dim) {
-    minX = Infinity;
-    minY = Infinity;
-    let maxX = -Infinity;
-    let maxY = -Infinity;
+    minX = data[0];
+    minY = data[1];
+    let maxX = minX;
+    let maxY = minY;
     for (let i = dim; i < outerLen; i += dim) {
       const x = data[i];
       const y = data[i + 1];
@@ -23361,7 +23361,7 @@ function pointInTriangleExceptFirst(ax, ay, bx, by, cx, cy, px, py) {
   return !(ax === px && ay === py) && pointInTriangle$1(ax, ay, bx, by, cx, cy, px, py);
 }
 function isValidDiagonal$1(a, b) {
-  return a.next.i !== b.i && a.prev.i !== b.i && !intersectsPolygon$1(a, b) && // dones't intersect other edges
+  return a.next.i !== b.i && a.prev.i !== b.i && !intersectsPolygon$1(a, b) && // doesn't intersect other edges
   (locallyInside$1(a, b) && locallyInside$1(b, a) && middleInside$1(a, b) && // locally visible
   (area$1(a.prev, a, b.prev) || area$1(a, b.prev, b)) || // does not create opposite-facing sectors
   equals$1(a, b) && area$1(a.prev, a, a.next) > 0 && area$1(b.prev, b, b.next) > 0);
@@ -29813,7 +29813,7 @@ class ItemConfigController {
   }
 }
 class MeshConnection {
-  constructor(modelId, connection) {
+  constructor(modelId, connection, multithreading) {
     __publicField(this, "_rate", 64);
     __publicField(this, "_updater");
     __publicField(this, "_modelId");
@@ -29829,6 +29829,14 @@ class MeshConnection {
     });
     this._modelId = modelId;
     this._connection = connection;
+    const configuredRate = multithreading == null ? void 0 : multithreading.meshConnectionRate;
+    if (Number.isFinite(configuredRate) && configuredRate >= 0) {
+      this._rate = configuredRate;
+    }
+    const configuredThreshold = multithreading == null ? void 0 : multithreading.meshConnectionThreshold;
+    if (Number.isFinite(configuredThreshold) && configuredThreshold >= 0) {
+      this._threshold = configuredThreshold;
+    }
     this._updater = MultithreadingHelper.newUpdater(this.refresh, this._rate);
   }
   get needsRefresh() {
@@ -30955,7 +30963,7 @@ const _LRUCache = class _LRUCache {
    * `cache.delete(key)`. `undefined` is never stored in the cache.
    */
   set(k, v, setOptions = {}) {
-    var _a2, _b2, _c3, _d, _e, _f, _g;
+    var _a2, _b2, _c, _d, _e, _f, _g;
     if (v === void 0) {
       this.delete(k);
       return this;
@@ -31000,7 +31008,7 @@ const _LRUCache = class _LRUCache {
               (_b2 = __privateGet(this, _dispose)) == null ? void 0 : _b2.call(this, s, k, "set");
             }
             if (__privateGet(this, _hasDisposeAfter)) {
-              (_c3 = __privateGet(this, _disposed)) == null ? void 0 : _c3.push([s, k, "set"]);
+              (_c = __privateGet(this, _disposed)) == null ? void 0 : _c.push([s, k, "set"]);
             }
           }
         } else if (!noDisposeOnSet) {
@@ -31653,7 +31661,7 @@ moveToTail_fn = function(index) {
 };
 _delete = new WeakSet();
 delete_fn = function(k, reason) {
-  var _a2, _b2, _c3, _d;
+  var _a2, _b2, _c, _d;
   let deleted = false;
   if (__privateGet(this, _size) !== 0) {
     const index = __privateGet(this, _keyMap).get(k);
@@ -31692,7 +31700,7 @@ delete_fn = function(k, reason) {
       }
     }
   }
-  if (__privateGet(this, _hasDisposeAfter) && ((_c3 = __privateGet(this, _disposed)) == null ? void 0 : _c3.length)) {
+  if (__privateGet(this, _hasDisposeAfter) && ((_c = __privateGet(this, _disposed)) == null ? void 0 : _c.length)) {
     const dt = __privateGet(this, _disposed);
     let task;
     while (task = dt == null ? void 0 : dt.shift()) {
@@ -31703,7 +31711,7 @@ delete_fn = function(k, reason) {
 };
 _clear = new WeakSet();
 clear_fn = function(reason) {
-  var _a2, _b2, _c3;
+  var _a2, _b2, _c;
   for (const index of __privateMethod(this, _rindexes, rindexes_fn).call(this, { allowStale: true })) {
     const v = __privateGet(this, _valList)[index];
     if (__privateMethod(this, _isBackgroundFetch, isBackgroundFetch_fn).call(this, v)) {
@@ -31737,7 +31745,7 @@ clear_fn = function(reason) {
     const dt = __privateGet(this, _disposed);
     let task;
     while (task = dt == null ? void 0 : dt.shift()) {
-      (_c3 = __privateGet(this, _disposeAfter)) == null ? void 0 : _c3.call(this, ...task);
+      (_c = __privateGet(this, _disposeAfter)) == null ? void 0 : _c.call(this, ...task);
     }
   }
 };
@@ -31887,7 +31895,11 @@ const _VirtualTilesController = class _VirtualTilesController {
     this._boxes = data.boxes;
     this._items = data.items;
     this._materials = data.materials;
-    this._meshConnection = new MeshConnection(data.modelId, data.connection);
+    this._meshConnection = new MeshConnection(
+      data.modelId,
+      data.connection,
+      data.multithreading
+    );
     this.meshes = data.model.meshes();
     this._sampleAmount = this.meshes.samplesLength();
     this._samples = new ItemConfigController(this._sampleAmount);
@@ -77894,31 +77906,6 @@ var IFC4X3;
   }
   IFC4X32.IfcController = IfcController;
 })(IFC4X3 || (IFC4X3 = {}));
-_c = class {
-  static setLogLevel(level) {
-    this.logLevel = level;
-  }
-  static log(msg, ...args) {
-    if (this.logLevel <= 4) {
-      console.log(msg, ...args);
-    }
-  }
-  static debug(msg, ...args) {
-    if (this.logLevel <= 1) {
-      console.trace("DEBUG: ", msg, ...args);
-    }
-  }
-  static warn(msg, ...args) {
-    if (this.logLevel <= 3) {
-      console.warn("WARN: ", msg, ...args);
-    }
-  }
-  static error(msg, ...args) {
-    if (this.logLevel <= 4) {
-      console.error("ERROR: ", msg, ...args);
-    }
-  }
-}, _c.logLevel = 4, _c;
 if (typeof document !== "undefined") {
   const currentScriptData = document.currentScript;
   if ((currentScriptData == null ? void 0 : currentScriptData.src) !== void 0)
@@ -78172,7 +78159,7 @@ class VirtualPropertiesController {
     return [...values];
   }
   getAttributesUniqueValues(params) {
-    var _a2, _b2, _c3;
+    var _a2, _b2, _c;
     const map = /* @__PURE__ */ new Map();
     const areCategoriesDefined = params.every(
       (value) => value.categories !== void 0
@@ -78238,7 +78225,7 @@ class VirtualPropertiesController {
           if (!(key && ((_b2 = attributeSet[key]) == null ? void 0 : _b2.value) !== void 0))
             continue;
           const mapKey = resultKey ?? key;
-          const value = (_c3 = attributeSet[key]) == null ? void 0 : _c3.value;
+          const value = (_c = attributeSet[key]) == null ? void 0 : _c.value;
           if (!map.has(mapKey)) {
             map.set(mapKey, /* @__PURE__ */ new Map());
           }
@@ -80721,6 +80708,7 @@ class VirtualFragmentsModel {
     return new VirtualTilesController({
       modelId: this._modelId,
       connection: this._connection,
+      multithreading: this._config.multithreading,
       model: this.data,
       boxes: this.boxes,
       items: this.itemConfig,
@@ -80742,6 +80730,7 @@ class ThreadModelCreator extends ThreadController {
     return MultiThreadingRequestClass.CREATE_MODEL;
   }
   async execute(input) {
+    var _a2, _b2;
     const { modelId } = input;
     const notify = this.createProgressNotifier(modelId);
     const throwIfAborted = () => {
@@ -80754,6 +80743,9 @@ class ThreadModelCreator extends ThreadController {
       this.inflate(input);
       notify("decompressing", 1);
       throwIfAborted();
+      this.thread.controllerManager.updater.setUpdateDelay(
+        (_b2 = (_a2 = input.config) == null ? void 0 : _a2.multithreading) == null ? void 0 : _b2.threadUpdaterDelay
+      );
       const model = await this.createModel(input, notify, throwIfAborted);
       this.finalize(input, model);
       notify("done", 1);
@@ -80977,6 +80969,12 @@ class ThreadUpdater {
       setTimeout(updateAll, delay);
     };
     updateAll();
+  }
+  setUpdateDelay(delay) {
+    if (typeof delay !== "number" || !Number.isFinite(delay) || delay < 0) {
+      return;
+    }
+    this._updateDelay = delay;
   }
   updateAllModels() {
     const start = performance.now();


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

In my app, I use the fragments model highlight to show selected items. But I noticed delays and the engine seems not performant. However, I discovered that this is not a performance issue that leads to this delay between my clicks and the view update, but rather hardcoded timeouts that seems pretty long !

The PR add no behavior change as it keeps the previous delays with the same default values. However, it adds to the user the ability the customize these delays.

The targeted class are `MeshConnection` and `ThreadUpdater`.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
