### PR TITLE
feat(split): return value

### DIFF
--- a/packages/fragments/src/Utils/ifc-splitter/index.ts
+++ b/packages/fragments/src/Utils/ifc-splitter/index.ts
@@ -149,7 +149,7 @@ const ELEMENT_TYPES: Set<string> = new Set([
   "IFCSHADINGDEVICE",
   "IFCCHIMNEY",
   "IFCGEOGRAPHICELEMENT",
-  "IFCPROXY", 
+  "IFCPROXY",
   "IFCMECHANICALFASTENER",
 ]);
 
@@ -830,7 +830,7 @@ export function split(
   inputPath: string,
   numGroups: number,
   outputDir?: string,
-): void {
+): Set<number>[] {
   const { fs, path } = deps;
   if (!fs.existsSync(inputPath)) {
     console.error(`File not found: ${inputPath}`);
@@ -1080,6 +1080,8 @@ export function split(
   console.timeEnd("write");
 
   console.log("\nDone!");
+
+  return groupsData.map((g) => g?.fileIds ?? new Set());
 }
 
 /**

--- a/packages/fragments/src/Utils/ifc-splitter/index.ts
+++ b/packages/fragments/src/Utils/ifc-splitter/index.ts
@@ -65,10 +65,11 @@ export interface StyleMaps {
 
 /** Per-group output data: the set of IFC entity IDs to include and any rewritten relationship lines. */
 export interface GroupData {
-  fileIds: Set<number> | null;
+  fileIds: Set<number>;
   rewrittenLines: Map<number, string>;
   elementCount: number;
   totalIds: number;
+  fileName: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -338,6 +339,7 @@ function forEachLine(
 // Buffered synchronous file writer — avoids per-line write() syscalls
 // ---------------------------------------------------------------------------
 class BufferedWriter {
+  readonly filePath: string;
   private fsLike: IfcSplitterFs;
   private fd: number;
   private buf: Buffer;
@@ -345,6 +347,7 @@ class BufferedWriter {
   private bufSize: number;
 
   constructor(fsLike: IfcSplitterFs, filePath: string, bufSize: number) {
+    this.filePath = filePath;
     this.fsLike = fsLike;
     this.fd = fsLike.openSync(filePath, "w");
     this.buf = Buffer.allocUnsafe(bufSize);
@@ -830,7 +833,7 @@ export function split(
   inputPath: string,
   numGroups: number,
   outputDir?: string,
-): Set<number>[] {
+): Map<string, Set<number>> {
   const { fs, path } = deps;
   if (!fs.existsSync(inputPath)) {
     console.error(`File not found: ${inputPath}`);
@@ -1039,6 +1042,10 @@ export function split(
       rewrittenLines,
       elementCount: groupElementIds.size,
       totalIds,
+      fileName: path.join(
+        resolvedOutputDir,
+        `split_${String(g + 1).padStart(3, "0")}.ifc`,
+      ),
     });
     console.log(
       `  Group ${g + 1}: ${groupElementIds.size} elements, ${totalIds} total IDs`,
@@ -1055,33 +1062,25 @@ export function split(
   console.time("build-mask");
   const idGroupMask = new Uint32Array(maxParsedId + 1);
   for (let g = 0; g < numGroups; g++) {
-    if (!groupsData[g]) continue;
+    const groupData = groupsData[g];
+    if (!groupData) continue;
     const bit = 1 << g;
-    for (const id of groupsData[g]!.fileIds!) {
+    for (const id of groupData.fileIds) {
       idGroupMask[id] |= bit;
     }
-  }
-  for (let g = 0; g < numGroups; g++) {
-    if (groupsData[g]) groupsData[g]!.fileIds = null;
   }
   console.timeEnd("build-mask");
 
   // 10. Second pass: write output files
   console.time("write");
-  writeOutputFiles(
-    deps,
-    inputPath,
-    resolvedOutputDir,
-    header,
-    footer,
-    groupsData,
-    idGroupMask,
-  );
+  writeOutputFiles(deps, inputPath, header, footer, groupsData, idGroupMask);
   console.timeEnd("write");
 
   console.log("\nDone!");
 
-  return groupsData.map((g) => g?.fileIds ?? new Set());
+  return new Map(
+    groupsData.filter((g) => !!g).map((g) => [g.fileName, g.fileIds]),
+  );
 }
 
 /**
@@ -1319,7 +1318,6 @@ function emitSingleLine(
 function writeOutputFiles(
   deps: IfcSplitterDeps,
   inputPath: string,
-  outputDir: string,
   header: string[],
   footer: string[],
   groupsData: (GroupData | null)[],
@@ -1331,15 +1329,12 @@ function writeOutputFiles(
   const writers: (BufferedWriter | null)[] = [];
   const headerStr = `${header.join("\n")}\n`;
   for (let g = 0; g < numGroups; g++) {
-    if (!groupsData[g]) {
+    const groupData = groupsData[g];
+    if (!groupData) {
       writers.push(null);
       continue;
     }
-    const outName = path.join(
-      outputDir,
-      `split_${String(g + 1).padStart(3, "0")}.ifc`,
-    );
-    const bw = new BufferedWriter(fs, outName, 4 * 1024 * 1024);
+    const bw = new BufferedWriter(fs, groupData.fileName, 4 * 1024 * 1024);
     bw.write(headerStr);
     writers.push(bw);
   }
@@ -1382,14 +1377,10 @@ function writeOutputFiles(
     if (!bw) continue;
     bw.write(footerStr);
     bw.close();
-    const outName = path.join(
-      outputDir,
-      `split_${String(g + 1).padStart(3, "0")}.ifc`,
-    );
-    const stat = fs.statSync(outName);
+    const stat = fs.statSync(bw.filePath);
     const gd = groupsData[g]!;
     console.log(
-      `  Group ${g + 1}: ${gd.elementCount} elements, ${gd.totalIds} total lines, ${(stat.size / 1024 / 1024).toFixed(1)} MB -> ${path.basename(outName)}`,
+      `  Group ${g + 1}: ${gd.elementCount} elements, ${gd.totalIds} total lines, ${(stat.size / 1024 / 1024).toFixed(1)} MB -> ${path.basename(bw.filePath)}`,
     );
   }
 }

--- a/packages/fragments/src/Utils/ifc-splitter/test.ts
+++ b/packages/fragments/src/Utils/ifc-splitter/test.ts
@@ -15,7 +15,8 @@ const numGroups = parseInt(args[1], 10);
 const outputDir = args[2] ? path.resolve(args[2]) : undefined;
 
 try {
-  split({ fs, path }, inputPath, numGroups, outputDir);
+  const splitMap = split({ fs, path }, inputPath, numGroups, outputDir);
+  console.log(splitMap);
 } catch (err) {
   console.error(err);
   process.exit(1);


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

`split`: Return a map of split files to localIds for the consumer

This provides both the generated file names, no need for guessing or `readdir` and provides localIds for indexing if needed

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
