### PR TITLE
fix(): vite config examples index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,20 +24,20 @@
   <body>
     <div style="display: flex; flex-direction: column; gap: 1rem;">
       <h3>Choose an example</h3>
-      <a style="width: fit-content;" href="./packages\fragments\src\Importers\IfcImporter\example.html">fragments/IfcImporter</a>
-<a style="width: fit-content;" href="./packages\fragments\src\Importers\IfcImporter\examples\HelloWorldSchema\example.html">fragments/HelloWorldSchema</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\example.html">fragments/FragmentsModels</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\VisibilityOperations\example.html">fragments/VisibilityOperations</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\ThreadGroups\example.html">fragments/ThreadGroups</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\SteelDetailing\example.html">fragments/SteelDetailing</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\Rebars\example.html">fragments/Rebars</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\Raycasting\example.html">fragments/Raycasting</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\ModelInformation\example.html">fragments/ModelInformation</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\Materials\example.html">fragments/Materials</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\EditProperties\example.html">fragments/EditProperties</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\EditElements\example.html">fragments/EditElements</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\EditApi\example.html">fragments/EditApi</a>
-<a style="width: fit-content;" href="./packages\fragments\src\FragmentsModels\examples\BuildingConfigurator\example.html">fragments/BuildingConfigurator</a>
+      <a style="width: fit-content;" href="./packages/fragments/src/Importers/IfcImporter/example.html">fragments/IfcImporter</a>
+<a style="width: fit-content;" href="./packages/fragments/src/Importers/IfcImporter/examples/HelloWorldSchema/example.html">fragments/HelloWorldSchema</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/example.html">fragments/FragmentsModels</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/VisibilityOperations/example.html">fragments/VisibilityOperations</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/ThreadGroups/example.html">fragments/ThreadGroups</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/SteelDetailing/example.html">fragments/SteelDetailing</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/Rebars/example.html">fragments/Rebars</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/Raycasting/example.html">fragments/Raycasting</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/ModelInformation/example.html">fragments/ModelInformation</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/Materials/example.html">fragments/Materials</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/EditProperties/example.html">fragments/EditProperties</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/EditElements/example.html">fragments/EditElements</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/EditApi/example.html">fragments/EditApi</a>
+<a style="width: fit-content;" href="./packages/fragments/src/FragmentsModels/examples/BuildingConfigurator/example.html">fragments/BuildingConfigurator</a>
 
     </div>
   </body>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,19 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import * as fs from "fs";
+import { globSync } from "glob";
 import * as path from "path";
 import { defineConfig } from "vite";
-import { globSync } from "glob";
 import * as fragmentsPackageJson from "./packages/fragments/package.json";
 
 const writeIndexHTML = () => {
   let links: string = "";
   const examplePaths = globSync("packages/**/src/**/example*.html");
   for (const examplePath of examplePaths) {
-    const directory = path.dirname(examplePath);
-    const packageNameMatch = directory.match(/packages\\([^\\]+)/);
-    if (!(packageNameMatch && packageNameMatch.length > 1)) continue;
-    const packageName = packageNameMatch[1];
-    const exampleName = path.basename(directory);
+    const directorySegments = path.dirname(examplePath).split(path.sep);
+    const packageName = directorySegments
+      .slice(1, directorySegments.indexOf("src"))
+      .join(path.sep);
+    const exampleName = directorySegments[directorySegments.length - 1];
     links += `<a style="width: fit-content;" href="./${examplePath}">${packageName}/${exampleName}</a>\n`;
   }
   const index = `

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,9 +12,9 @@ const writeIndexHTML = () => {
     const directorySegments = path.dirname(examplePath).split(path.sep);
     const packageName = directorySegments
       .slice(1, directorySegments.indexOf("src"))
-      .join(path.sep);
+      .join("/");
     const exampleName = directorySegments[directorySegments.length - 1];
-    links += `<a style="width: fit-content;" href="./${examplePath}">${packageName}/${exampleName}</a>\n`;
+    links += `<a style="width: fit-content;" href="./${directorySegments.join("/")}">${packageName}/${exampleName}</a>\n`;
   }
   const index = `
   <!DOCTYPE html>


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Fixes the index.html file generated by vite.
It had an error with the regexp, didn't work on macOS.
