### PR TITLE
fix(raycaster): full precision result.facePoints

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/raycast-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/raycast-controller.ts
@@ -347,16 +347,19 @@ export class RaycastController {
       if ("facePoints" in result) {
         const sample = this._meshes.samples(id, this._temp.sample)!;
         TransformHelper.get(sample, this._meshes, this._temp.m3);
-        for (let i = 0; i < result.facePoints.length; i += 3) {
-          const x = result.facePoints[i];
-          const y = result.facePoints[i + 1];
-          const z = result.facePoints[i + 2];
+        const sourceFacePoints = result.facePoints;
+        const transformedFacePoints = new Float64Array(sourceFacePoints.length);
+        for (let i = 0; i < sourceFacePoints.length; i += 3) {
+          const x = sourceFacePoints[i];
+          const y = sourceFacePoints[i + 1];
+          const z = sourceFacePoints[i + 2];
           this._temp.v1.set(x, y, z);
           this._temp.v1.applyMatrix4(this._temp.m3);
-          result.facePoints[i] = this._temp.v1.x;
-          result.facePoints[i + 1] = this._temp.v1.y;
-          result.facePoints[i + 2] = this._temp.v1.z;
+          transformedFacePoints[i] = this._temp.v1.x;
+          transformedFacePoints[i + 1] = this._temp.v1.y;
+          transformedFacePoints[i + 2] = this._temp.v1.z;
         }
+        result.facePoints = transformedFacePoints;
       }
 
       result.sampleId = id;


### PR DESCRIPTION
### Description

I have implemented a face hoverer in the same idea of the engine_component Hoverer, by creating a mesh from the raycast result facePoints and faceIndices. However on models with large coordinates, the raycast result face points array is lacking precision due to float32 limitation. This PR just change the Float32Array facePoints array by a Float64Array.

In the formatRaycastResult method, the duo matrix get from TransformHelper (set in this._temp.m3) + untransformed facePoints have all precision, but as soon as  this code execute:

```js
          this._temp.v1.set(x, y, z);
          this._temp.v1.applyMatrix4(this._temp.m3);
          result.facePoints[i] = this._temp.v1.x;
          result.facePoints[i + 1] = this._temp.v1.y;
          result.facePoints[i + 2] = this._temp.v1.z;
```
Because facePoints is a Float32Array and the transformation matrix is not provided in the result, precision is lost.

#### Before:

Misaligned face:

<img width="602" height="316" alt="Screenshot 2026-05-06 at 11 39 16" src="https://github.com/user-attachments/assets/156a9664-04e8-4c21-a246-b1e9c3f8402c" />

#### After:

Perfectly aligned face:

<img width="596" height="395" alt="Screenshot 2026-05-06 at 11 29 02" src="https://github.com/user-attachments/assets/84762135-5043-4d3d-95c2-18e30b42d6c9" />



### Additional context

With the fix and thanks to the full precision facePoints: Float64Array , I recreate the face mesh with a position computed from the bound sphere:

```js
    const result = await caster.castRay({ position: mousePosition });

    // change Float64Array into Array<Vector3>
    const worldVertices = result.facePoints.reduce((acc, value, index) => {
      const vecIndex = Math.floor(index / 3);
      if (!acc[vecIndex]) acc[vecIndex] = new THREE.Vector3();
      acc[vecIndex].setComponent(index % 3, value);
      return acc;
    }, []);

    if (worldVertices.length < 3) return null;

    const bounds = new THREE.Box3();
    worldVertices.forEach((vertex) => bounds.expandByPoint(vertex));
    const renderOrigin = bounds.isEmpty()
      ? worldVertices[0].clone()
      : bounds.getCenter(new THREE.Vector3());
      
    // ...
    
    faceMesh.position.copy(renderOrigin);
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
