### PR TITLE
fix(editor): swap models in editor.save() without blank-frame flicker

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/edit/edit-helper.ts
+++ b/packages/fragments/src/FragmentsModels/src/edit/edit-helper.ts
@@ -92,10 +92,12 @@ export class EditHelper {
     const camera = model.camera || undefined;
     const newModelBuffer = await model._save();
 
-    // Dispose all model
-    await model.dispose();
+    // Free up the modelId slot in the worker + registries, but keep the
+    // model's THREE object, tiles and materials in scene so the user does
+    // not see a blank frame while the new model loads.
+    await model.dispose({ keepInScene: true });
 
-    // Add new model
+    // Load new model with the same id (the slot is now free).
     const newModel = await this._fragments.load(newModelBuffer as any, {
       modelId,
       raw: true,
@@ -108,6 +110,9 @@ export class EditHelper {
     if (parent) {
       parent.add(newModel.object);
     }
+
+    // New model is in scene now. Tear down the old visuals.
+    model.finalizeDispose();
 
     // Return actions (e.g. to create action history, control z, etc.)
     return requests;

--- a/packages/fragments/src/FragmentsModels/src/model/data-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/data-manager.ts
@@ -19,10 +19,20 @@ export class DataManager {
     meshes: MeshManager,
     alignments: AlignmentsManager,
     grids: GridsManager,
+    options?: { keepInScene?: boolean },
   ) {
     meshes.list.delete(model.modelId);
     await this.requestModelDelete(model);
     model.threads.delete(model.modelId);
+    if (options?.keepInScene) {
+      // Free the modelId slot in the shared MaterialManager so the
+      // replacement model can register its own definitions without
+      // appending to ours (which would corrupt material indices). The
+      // actual THREE materials in `list` stay alive so the outgoing
+      // tiles keep rendering until `finalizeDispose` runs.
+      meshes.materials.releaseModelSlot(model.modelId);
+      return;
+    }
     model.object.removeFromParent();
     this.deleteAllTiles(model);
     meshes.materials.dispose(model.modelId);

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
@@ -223,8 +223,15 @@ export class FragmentsModel {
   /**
    * Dispose the model. Use this when you're done with the model.
    * If you use the {@link FragmentsModels.dispose} method, this will be called automatically for all models.
+   *
+   * @param options.keepInScene - If true, frees the model's worker slot,
+   *   registry entries and shared MaterialManager slot but leaves the THREE
+   *   object, tiles, materials in `list`, alignments and grids in place.
+   *   Caller must finalize the visual cleanup later via
+   *   {@link finalizeDispose}. Used by `editor.save()` to swap in a freshly
+   *   loaded model without a blank frame.
    */
-  async dispose() {
+  async dispose(options?: { keepInScene?: boolean }) {
     this._isLoaded = false;
     this.visibleItems.clear();
     this.onViewUpdated.reset();
@@ -233,7 +240,33 @@ export class FragmentsModel {
       this._meshManager,
       this._alignmentsManager,
       this._gridsManager,
+      options,
     );
+  }
+
+  /**
+   * Finalize a deferred dispose. Removes the THREE object from its parent,
+   * tears down tile meshes (geometry only — materials are shared via the
+   * MaterialManager and may be reused by a replacement model under the
+   * same modelId), and disposes the model's alignments and grids.
+   *
+   * Only call this after `dispose({ keepInScene: true })`. The tile map
+   * is cleared with events disabled to bypass the onBeforeDelete listener
+   * registered in the constructor (which would otherwise dispose tile
+   * materials).
+   */
+  finalizeDispose() {
+    this.object.removeFromParent();
+
+    this.tiles.eventsEnabled = false;
+    for (const [, mesh] of this.tiles) {
+      this.object.remove(mesh);
+      mesh.geometry.dispose();
+    }
+    this.tiles.clear();
+
+    this._alignmentsManager.dispose();
+    this._gridsManager.dispose();
   }
 
   /**

--- a/packages/fragments/src/FragmentsModels/src/model/material-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/material-manager.ts
@@ -49,6 +49,17 @@ export class MaterialManager {
     this._modelMaterialMapping.delete(modelId);
   }
 
+  /**
+   * Release a model's slot in the per-model definitions and mapping tables
+   * without disposing the underlying THREE materials in `list`. Used by
+   * `editor.save()` so a fresh model can register under the same modelId
+   * while the outgoing model's tiles still render normally.
+   */
+  releaseModelSlot(modelId: string) {
+    this._definitions.delete(modelId);
+    this._modelMaterialMapping.delete(modelId);
+  }
+
   get(data: MaterialDefinition, request: any) {
     const { modelId, objectClass, currentLod, templateId } = request;
     if (!(modelId && objectClass !== undefined && currentLod !== undefined)) {


### PR DESCRIPTION
Closes #207.

## Summary

`editor.save(modelId)` previously disposed the outgoing model — removing its `THREE.Object3D` from the scene and tearing down geometry, materials, alignments and grids — before loading the replacement. This left a one-or-more-frame window with nothing rendered for that modelId, producing a visible flicker.

This PR reorders `save()` so the replacement is fully loaded and added to the scene before the old model's visuals are torn down. See #207 for the full diagnosis.

## Changes

* **`FragmentsModel.dispose({ keepInScene })`** — phase 1 of a deferred dispose. Frees only the worker slot, the `meshes.list` entry, the threads routing entry, and the model's slot in the shared `MaterialManager` so the replacement can register under the same modelId. The `THREE.Object3D`, tile meshes, materials in `list`, alignments and grids are left untouched and continue rendering.

* **`MaterialManager.releaseModelSlot(modelId)`** — clears `_definitions[modelId]` and `_modelMaterialMapping[modelId]` without disposing the underlying THREE materials in `list`. Required because `addDefinitions()` *appends* to any existing array under that modelId; leaving the outgoing slot in place would corrupt the replacement model's material indices when its `CREATE_MATERIAL` requests arrive.

* **`FragmentsModel.finalizeDispose()`** — phase 2, called after the replacement is in the scene. Does `removeFromParent()`, disposes per-tile geometries, and disposes alignments + grids. It deliberately does **not** dispose materials: they are CRC-keyed (with `modelId` in the CRC) and `getUniqueMaterial` returns existing entries from `list`, so the replacement model frequently reuses the same instances. Picker materials also flow through `MaterialManager.list`, so disposing them here would silently break picking/highlighting/raycasting on the replacement model. The tile map is cleared with events disabled to bypass the constructor's `onBeforeDelete` listener (which would otherwise dispose tile materials).

* **`EditHelper.save()`** — uses the two phases:

  ```ts
  await model.dispose({ keepInScene: true });  // phase 1
  const newModel = await this._fragments.load(...);
  await newModel._setRequests({ undoneRequests: requests.undoneRequests });
  if (parent) parent.add(newModel.object);
  model.finalizeDispose();                      // phase 2
  ```

## Behaviour change

* Public API of `dispose()` is backward compatible — `keepInScene` is a new optional flag that defaults to false.
* `finalizeDispose()` is new public surface; it is only meaningful after `dispose({ keepInScene: true })`.
* `MaterialManager.releaseModelSlot()` is new public surface.

## Verification

Tested end-to-end against fragments built from this branch:

* Paste-on-element flow that calls `editor.save()` on every commit no longer flickers.
* Picking, highlighting and raycasting continue to work on the replacement model.
* Subsequent edits and saves keep working across many cycles.

Build is bit-identical to the published `@thatopen/fragments@3.4.5` for the unchanged code paths (verified via md5 on built `dist/` files before applying this patch).


