### PR TITLE
fix(SingleThreadedFragmentsModel)!: expose `raw` arg defaulting to `false`

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
+++ b/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
@@ -387,11 +387,12 @@ export class SingleThreadedFragmentsModel {
    * Apply a batch of edit requests. Accumulates onto this model's
    * pending-edit history; call {@link save} to flatten them into a new
    * committed buffer or {@link reset} to discard.
-   * @returns The delta flatbuffer bytes and the local IDs assigned to
+   * @param [raw] whether to return the raw buffer or the the result of {@link pako.deflate}.
+   * @returns The delta raw/deflated flatbuffer bytes and the local IDs assigned to
    * any newly-created items.
    */
-  edit(requests: EditRequest[]) {
-    return this._virtualModel.edit(requests);
+  edit(requests: EditRequest[], raw = false) {
+    return this._virtualModel.edit(requests, raw);
   }
 
   /** Discard all pending edits on this model. */
@@ -401,10 +402,11 @@ export class SingleThreadedFragmentsModel {
 
   /**
    * Flatten the current pending-edit history into a new committed buffer.
-   * @returns The raw flatbuffer bytes of the updated model.
+   * @param [raw] whether to return the raw buffer or the the result of {@link pako.deflate}.
+   * @returns The raw/deflated flatbuffer bytes of the updated model.
    */
-  save() {
-    return this._virtualModel.save();
+  save(raw = false) {
+    return this._virtualModel.save(raw);
   }
 
   /** Undo the last edit. */

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
@@ -137,7 +137,10 @@ export class VirtualFragmentsModel {
     return this.indexes.getEntry(name, key);
   }
 
-  getInverseIndexEntry(name: string, value: string | number): InverseIndexEntry {
+  getInverseIndexEntry(
+    name: string,
+    value: string | number,
+  ): InverseIndexEntry {
     return this.indexes.getInverseEntry(name, value);
   }
 
@@ -498,11 +501,11 @@ export class VirtualFragmentsModel {
 
     // Generate a delta model containing only these items + their geometry
     const { model } = EditUtils.edit(this.data, requests, {
-      raw: true,
+      raw,
       delta: true,
     });
 
-    return raw ? model : pako.deflate(model as ArrayBuffer);
+    return model;
   }
 
   dispose() {
@@ -564,14 +567,14 @@ export class VirtualFragmentsModel {
     return this.tiles.tilesUpdated;
   }
 
-  edit(requests: EditRequest[]) {
+  edit(requests: EditRequest[], raw = false) {
     const ids = EditUtils.solveIds(requests, this._nextId);
     this._nextId += ids.length;
     for (const request of requests) {
       this.requests.push(request);
     }
     const { model, items } = EditUtils.edit(this.data, this.requests, {
-      raw: true,
+      raw,
       delta: true,
     });
     // Clear the previous hidden-for-edit set before applying the new one.
@@ -588,13 +591,13 @@ export class VirtualFragmentsModel {
     this._nextId = this.getMaxLocalId();
   }
 
-  save() {
+  save(raw = false) {
     this.requests.push({
       type: EditRequestType.UPDATE_MAX_LOCAL_ID,
       localId: this._nextId,
     });
     const { model } = EditUtils.edit(this.data, this.requests, {
-      raw: true,
+      raw,
       delta: false,
     });
     return model;


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

SingleThreadedFragmentsModel#save and SingleThreadedFragmentsModel#edit returned a raw buffer. This does not align with the rest of the API, which defaults to `false`.
I have exposed `raw` as a last arg defaulting to false.
Should we add a comment that runtime editing should use `raw` in order to avoid deflating/inflating for performance reasons?

fixes https://github.com/ThatOpen/engine_fragment/issues/186#issuecomment-4442018353

### Additional context

Before this fix
```typescript
const model = new SingleThreadedFragmentsModel("my-model", buffer);
const newBuf = model.save();
new SingleThreadedFragmentsModel("my-model", newBuf); // fails
new SingleThreadedFragmentsModel("my-model", newBuf, true); // succeeds
```

After this fix
```typescript
const model = new SingleThreadedFragmentsModel("my-model", buffer);
const newBuf = model.save();
new SingleThreadedFragmentsModel("my-model", newBuf);
const newRawBuf = model.save(true);
new SingleThreadedFragmentsModel("my-model", newBuf, true);
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
