### PR TITLE
fix: render faces whose normal has two equal components

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/utils/geometry/face-utils.ts
+++ b/packages/fragments/src/FragmentsModels/src/utils/geometry/face-utils.ts
@@ -12,7 +12,12 @@ export class FaceUtils {
     const yDim = 1;
     const zDim = 2;
 
-    const isMostlyHorizontal = absZ > absX && absZ > absY;
+    // Use `>=` so that faces whose normal has two equal components
+    // (e.g. a 45° slope with normal (0, ±√2/2, ±√2/2)) still pick a
+    // dominant axis instead of falling through to the X-axis branch,
+    // which would project onto a plane parallel to the face and collapse
+    // it to a 1D line — earcut would then emit zero triangles.
+    const isMostlyHorizontal = absZ >= absX && absZ >= absY;
     if (isMostlyHorizontal) {
       const lookingUp = normal.z > 0;
       if (lookingUp) {
@@ -21,7 +26,7 @@ export class FaceUtils {
       return [yDim, xDim];
     }
 
-    const isMostlyLookingToY = absY > absX && absY > absZ;
+    const isMostlyLookingToY = absY >= absX && absY >= absZ;
     if (isMostlyLookingToY) {
       const isLookingYPositive = normal.y > 0;
       if (isLookingYPositive) {


### PR DESCRIPTION
### Description

Fixes #206 — IFCROOF faces missing with default `IfcImporter` shell conversion.

In `FaceUtils.getEarcutDimensions` the dominant-axis checks used strict `>`, so a face whose normal has two equal components — e.g. a 45° roof slope with normal `(0, ±√2/2, ±√2/2)` — failed *both* the `isMostlyHorizontal` and `isMostlyLookingToY` checks and fell through to the X-axis branch. That branch returns `[Y, Z]`, but on a YZ-diagonal plane every vertex satisfies `z ± y = const`, so the `(Y, Z)` projection collapses the polygon to a 1D line. Earcut then emits zero triangles and the face disappears from the rendered geometry.

Switching both checks from `>` to `>=` makes the function pick a valid (non-parallel) projection plane on ties, and the missing roof faces render correctly.

### Additional context

- The bug only manifests when a face normal has two tied dominant components (45°, 135°, …). Axis-aligned and arbitrary-angle faces are unaffected, which is why this slipped through.
- Reproduction file and affected `IFCROOF` are in #206.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.