### PR TITLE
fix(SingleThreadedFragmentsModel): `getItemsChildren` return value

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
+++ b/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
@@ -196,7 +196,7 @@ export class SingleThreadedFragmentsModel {
    * @param ids - The IDs of the items to look up.
    */
   getItemsChildren(ids: Identifier[]) {
-    this._virtualModel.getItemsChildren(ids);
+    return this._virtualModel.getItemsChildren(ids);
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Fixes a missing return
Related to #216, enforcing `class X implements interface Y` would have caught this bug

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
