### PR TITLE
feat(Indexes): method generic types for better DX

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/model/data-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/data-manager.ts
@@ -6,7 +6,6 @@ import {
   ItemsQueryConfig,
   IndexEntry,
   IndexInfo,
-  InverseIndexEntry,
   IndexArrayType,
 } from "./model-types";
 import { AlignmentsManager } from "./alignments-manager";
@@ -83,7 +82,7 @@ export class DataManager {
     return model.threads.invoke(model.modelId, "getIndexEntry", [
       name,
       key,
-    ]) as Promise<V>;
+    ]) as Promise<V | null>;
   }
 
   async getInverseIndexEntry<

--- a/packages/fragments/src/FragmentsModels/src/model/data-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/data-manager.ts
@@ -7,6 +7,7 @@ import {
   IndexEntry,
   IndexInfo,
   InverseIndexEntry,
+  IndexArrayType,
 } from "./model-types";
 import { AlignmentsManager } from "./alignments-manager";
 import { FragmentsModel } from "./fragments-model";
@@ -54,16 +55,19 @@ export class DataManager {
     ]) as Promise<IndexInfo | null>;
   }
 
-  async getIndexKeys(model: FragmentsModel, name: string) {
-    return model.threads.invoke(model.modelId, "getIndexKeys", [
-      name,
-    ]) as Promise<Uint32Array | string[] | null>;
-  }
-
-  async hasIndexEntry(
+  async getIndexKeys<K extends string | number>(
     model: FragmentsModel,
     name: string,
-    key: string | number,
+  ) {
+    return model.threads.invoke(model.modelId, "getIndexKeys", [
+      name,
+    ]) as Promise<IndexArrayType<K> | null>;
+  }
+
+  async hasIndexEntry<K extends string | number>(
+    model: FragmentsModel,
+    name: string,
+    key: K,
   ) {
     return model.threads.invoke(model.modelId, "hasIndexEntry", [
       name,
@@ -71,26 +75,25 @@ export class DataManager {
     ]) as Promise<boolean>;
   }
 
-  async getIndexEntry(
+  async getIndexEntry<K extends string | number, V extends IndexEntry>(
     model: FragmentsModel,
     name: string,
-    key: string | number,
+    key: K,
   ) {
     return model.threads.invoke(model.modelId, "getIndexEntry", [
       name,
       key,
-    ]) as Promise<IndexEntry>;
+    ]) as Promise<V>;
   }
 
-  async getInverseIndexEntry(
-    model: FragmentsModel,
-    name: string,
-    value: string | number,
-  ) {
+  async getInverseIndexEntry<
+    K extends string | number,
+    V extends string | number,
+  >(model: FragmentsModel, name: string, value: K) {
     return model.threads.invoke(model.modelId, "getInverseIndexEntry", [
       name,
       value,
-    ]) as Promise<InverseIndexEntry>;
+    ]) as Promise<IndexArrayType<V>>;
   }
 
   async getMaxLocalId(model: FragmentsModel) {

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
@@ -19,6 +19,8 @@ import {
   CurrentLod,
   ItemsQueryConfig,
   LodMode,
+  IndexEntry,
+  InverseIndexEntry,
 } from "./model-types";
 
 import { MiscHelper } from "../utils";
@@ -289,14 +291,14 @@ export class FragmentsModel {
    * iteration) but valid for any mode. Number keys come back as a
    * `Uint32Array`, string keys as `string[]`.
    */
-  async getIndexKeys(name: string) {
-    return this._dataManager.getIndexKeys(this, name);
+  async getIndexKeys<K extends string | number>(name: string) {
+    return this._dataManager.getIndexKeys<K>(this, name);
   }
 
   /**
    * Test whether a key exists in the named index without resolving its value.
    */
-  async hasIndexEntry(name: string, key: string | number) {
+  async hasIndexEntry<K extends string | number>(name: string, key: K) {
     return this._dataManager.hasIndexEntry(this, name, key);
   }
 
@@ -304,8 +306,11 @@ export class FragmentsModel {
    * Forward lookup of a single entry in the named index. The return shape
    * depends on the index mode (see {@link IndexEntry}).
    */
-  async getIndexEntry(name: string, key: string | number) {
-    return this._dataManager.getIndexEntry(this, name, key);
+  async getIndexEntry<K extends string | number, V extends IndexEntry>(
+    name: string,
+    key: K,
+  ) {
+    return this._dataManager.getIndexEntry<K, V>(this, name, key);
   }
 
   /**
@@ -313,8 +318,11 @@ export class FragmentsModel {
    * returns every key that maps to `value`. The inverse map is built lazily
    * on first call and cached for the model's lifetime.
    */
-  async getInverseIndexEntry(name: string, value: string | number) {
-    return this._dataManager.getInverseIndexEntry(this, name, value);
+  async getInverseIndexEntry<
+    K extends string | number,
+    V extends string | number,
+  >(name: string, value: K) {
+    return this._dataManager.getInverseIndexEntry<K, V>(this, name, value);
   }
 
   async getItemsWithGeometryCategories() {
@@ -492,7 +500,7 @@ export class FragmentsModel {
       this.modelId,
       "getAttributesUniqueValues",
       [params],
-    )) as Record<string, { value: any, localIds: number[] }[]>;
+    )) as Record<string, { value: any; localIds: number[] }[]>;
     return values;
   }
 

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
@@ -20,7 +20,6 @@ import {
   ItemsQueryConfig,
   LodMode,
   IndexEntry,
-  InverseIndexEntry,
 } from "./model-types";
 
 import { MiscHelper } from "../utils";

--- a/packages/fragments/src/FragmentsModels/src/model/model-types.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/model-types.ts
@@ -434,7 +434,7 @@ export interface IndexInfo {
  * values) for the 1:N modes. The `Uint32Array` is a zero-copy view over the
  * underlying buffer; do not mutate it.
  */
-export type IndexEntry = string | number | Uint32Array | string[] | null;
+export type IndexEntry = string | number | Uint32Array | string[];
 
 /**
  * Inverse-lookup result. For an index with forward direction `key -> value`,

--- a/packages/fragments/src/FragmentsModels/src/model/model-types.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/model-types.ts
@@ -132,10 +132,10 @@ export type MaterialDefinition = {
 
   /** The local ID of the material */
   localId?: number;
-  
+
   /**
    * Internal array tracking which properties were explicitly set by the caller.
-   * Used with preserveOriginalMaterial to avoid overwriting original material 
+   * Used with preserveOriginalMaterial to avoid overwriting original material
    * properties with default values during serialization.
    */
   _explicitProps?: string[];
@@ -442,6 +442,12 @@ export type IndexEntry = string | number | Uint32Array | string[] | null;
  * for number-keyed indexes and `string[]` for string-keyed ones.
  */
 export type InverseIndexEntry = Uint32Array | string[] | null;
+
+export type IndexArrayType<T extends string | number> = T extends string
+  ? string[]
+  : T extends number
+    ? Uint32Array
+    : never;
 
 /**
  * Interface representing the configuration for item data in a Fragments model.

--- a/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
+++ b/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
@@ -4,7 +4,6 @@ import {
   CurrentLod,
   Identifier,
   IndexEntry,
-  InverseIndexEntry,
   ItemsDataConfig,
   ItemsQueryConfig,
   ItemsQueryParams,

--- a/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
+++ b/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
@@ -3,6 +3,8 @@ import pako from "pako";
 import {
   CurrentLod,
   Identifier,
+  IndexEntry,
+  InverseIndexEntry,
   ItemsDataConfig,
   ItemsQueryConfig,
   ItemsQueryParams,
@@ -104,14 +106,14 @@ export class SingleThreadedFragmentsModel {
    * iteration) but valid for any mode. Number keys come back as a
    * `Uint32Array`, string keys as `string[]`.
    */
-  getIndexKeys(name: string) {
-    return this._virtualModel.getIndexKeys(name);
+  getIndexKeys<K extends string | number>(name: string) {
+    return this._virtualModel.getIndexKeys<K>(name);
   }
 
   /**
    * Test whether a key exists in the named index without resolving its value.
    */
-  hasIndexEntry(name: string, key: string | number) {
+  hasIndexEntry<K extends string | number>(name: string, key: K) {
     return this._virtualModel.hasIndexEntry(name, key);
   }
 
@@ -119,15 +121,21 @@ export class SingleThreadedFragmentsModel {
    * Forward lookup of a single entry in the named index. The return shape
    * depends on the index mode.
    */
-  getIndexEntry(name: string, key: string | number) {
-    return this._virtualModel.getIndexEntry(name, key);
+  getIndexEntry<K extends string | number, V extends IndexEntry>(
+    name: string,
+    key: K,
+  ) {
+    return this._virtualModel.getIndexEntry<K, V>(name, key);
   }
 
   /**
    * Inverse lookup. Returns every key that maps to `value`.
    */
-  getInverseIndexEntry(name: string, value: string | number) {
-    return this._virtualModel.getInverseIndexEntry(name, value);
+  getInverseIndexEntry<K extends string | number, V extends string | number>(
+    name: string,
+    value: K,
+  ) {
+    return this._virtualModel.getInverseIndexEntry<K, V>(name, value);
   }
 
   /**

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-indexes-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-indexes-controller.ts
@@ -130,7 +130,7 @@ export class VirtualIndexesController {
    * mode (see {@link IndexEntry}). Returns `null` if the index or key is
    * missing, or the key type doesn't match.
    */
-  getEntry(name: string, key: string | number): IndexEntry {
+  getEntry(name: string, key: string | number): IndexEntry | null {
     const entry = this.resolve(name);
     if (!entry) return null;
     if (typeof key !== entry.info.keyType) return null;

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
@@ -33,7 +33,6 @@ import {
   ItemsQueryConfig,
   IndexEntry,
   IndexInfo,
-  InverseIndexEntry,
   LodMode,
   IndexArrayType,
 } from "../model/model-types";
@@ -139,8 +138,8 @@ export class VirtualFragmentsModel {
   getIndexEntry<K extends string | number, V extends IndexEntry>(
     name: string,
     key: K,
-  ): V {
-    return this.indexes.getEntry(name, key) as V;
+  ): V | null {
+    return this.indexes.getEntry(name, key) as V | null;
   }
 
   getInverseIndexEntry<K extends string | number, V extends string | number>(

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
@@ -35,6 +35,7 @@ import {
   IndexInfo,
   InverseIndexEntry,
   LodMode,
+  IndexArrayType,
 } from "../model/model-types";
 
 import { VirtualBoxController } from "../bounding-boxes";
@@ -125,20 +126,28 @@ export class VirtualFragmentsModel {
     return this.indexes.getInfo(name);
   }
 
-  getIndexKeys(name: string): Uint32Array | string[] | null {
-    return this.indexes.getKeys(name);
+  getIndexKeys<K extends string | number>(
+    name: string,
+  ): IndexArrayType<K> | null {
+    return this.indexes.getKeys(name) as IndexArrayType<K> | null;
   }
 
-  hasIndexEntry(name: string, key: string | number): boolean {
+  hasIndexEntry<K extends string | number>(name: string, key: K): boolean {
     return this.indexes.has(name, key);
   }
 
-  getIndexEntry(name: string, key: string | number): IndexEntry {
-    return this.indexes.getEntry(name, key);
+  getIndexEntry<K extends string | number, V extends IndexEntry>(
+    name: string,
+    key: K,
+  ): V {
+    return this.indexes.getEntry(name, key) as V;
   }
 
-  getInverseIndexEntry(name: string, value: string | number): InverseIndexEntry {
-    return this.indexes.getInverseEntry(name, value);
+  getInverseIndexEntry<K extends string | number, V extends string | number>(
+    name: string,
+    value: K,
+  ): IndexArrayType<V> {
+    return this.indexes.getInverseEntry(name, value) as IndexArrayType<V>;
   }
 
   getItemsByConfig(condition: (item: number) => boolean) {


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Add generic types to index read methods for ease of use

**Before**
```typescript
const keys = model.getIndexKeys(name) as Uint32Array
```

**After**
```typescript
const keys = model.getIndexKeys<number>(name)
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

#215 needs to be patched with a generic type

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
