### PR TITLE
fix(SingleThreadedFragmentsModel): apply common fragments model interface

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/index.ts
+++ b/packages/fragments/src/FragmentsModels/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./model/model-types";
+export type { IFragmentsModel } from "./model/fragments-model-interface";
 export { FragmentsModel } from "./model";
 export { SingleThreadedFragmentsModel } from "./single-threading";
 export { isRawBuffer } from "./utils/misc/buffer";

--- a/packages/fragments/src/FragmentsModels/src/model/coordinates-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/coordinates-manager.ts
@@ -43,7 +43,10 @@ export class CoordinatesManager {
 
   async getCoordinates(model: FragmentsModel) {
     const id = model.modelId;
-    return model.threads.invoke(id, "getCoordinates") as Promise<number[]>;
+    return model.threads.invoke(
+      id,
+      "getCoordinates",
+    ) as Promise<THREE.Matrix3Tuple>;
   }
 
   async getPositions(model: FragmentsModel, localIds?: number[]) {

--- a/packages/fragments/src/FragmentsModels/src/model/coordinates-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/coordinates-manager.ts
@@ -43,10 +43,7 @@ export class CoordinatesManager {
 
   async getCoordinates(model: FragmentsModel) {
     const id = model.modelId;
-    return model.threads.invoke(
-      id,
-      "getCoordinates",
-    ) as Promise<THREE.Matrix3Tuple>;
+    return model.threads.invoke(id, "getCoordinates") as Promise<number[]>;
   }
 
   async getPositions(model: FragmentsModel, localIds?: number[]) {

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
@@ -102,6 +102,7 @@ export interface IModelGeometry<Async extends boolean> {
     localIds: number[],
     lod?: CurrentLod,
   ): Promisify<MeshData[][], Async>;
+  getItemsVolume(localIds: number[]): Promisify<number, Async>;
   getItemDrawChunks(localIds: Iterable<number>): Promisify<DrawChunk[], Async>;
   getSection(
     plane: THREE.Plane,

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
@@ -64,7 +64,7 @@ export interface IItemsQuery<Async extends boolean> {
    * MISALIGNMENT: FragmentsModel's `DataManager` maps the raw local IDs into
    * `Item[]` objects; SingleThreaded and VirtualFragmentsModel return `number[]`.
    */
-  getItemsWithGeometry(): Promisify<number[], Async>;
+  getItemsIdsWithGeometry(): Promisify<number[], Async>;
   getItemsOfCategories(
     categories: RegExp[],
   ): Promisify<Record<string, number[]>, Async>;

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
@@ -143,11 +143,11 @@ export interface IModelIndex<Async extends boolean> {
 
 /** Binary serialization of the full model or an item subset. */
 export interface IModelSerializer<Async extends boolean> {
-  getBuffer(raw?: boolean): Promisify<ArrayBuffer | Uint8Array, Async>;
+  getBuffer(raw?: boolean): Promisify<ArrayBufferLike | Uint8Array, Async>;
   getSubsetBuffer(
     localIds: number[],
     raw?: boolean,
-  ): Promisify<ArrayBuffer | Uint8Array, Async>;
+  ): Promisify<ArrayBufferLike | Uint8Array, Async>;
 }
 
 export interface IFragmentsModel<Async extends boolean = false>

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import {
+import type {
   RawGlobalTransformData,
   RawItemData,
   RawMaterial,
@@ -8,7 +8,8 @@ import {
   RawSample,
   RawTransformData,
 } from "../../../Utils";
-import {
+import type { VirtualIndexesController } from "../virtual-model";
+import type {
   CRSData,
   CurrentLod,
   Identifier,
@@ -38,32 +39,16 @@ export type DrawChunk = {
   size: Uint32Array;
 };
 
-/** Model metadata, spatial structure, categories, and CRS. */
-export interface IModelProperties<Async extends boolean> {
+export interface IModelData<Async extends boolean> {
   getSpatialStructure(): Promisify<SpatialTreeItem, Async>;
   getCategories(): Promisify<string[], Async>;
   getMetadata<T extends Record<string, any>>(): Promisify<T, Async>;
   getCRS(): Promisify<CRSData | null, Async>;
-}
-
-/** Local-ID / GUID / item-ID translation and enumeration. */
-export interface IModelIds<Async extends boolean> {
   getMaxLocalId(): Promisify<number, Async>;
   getLocalIds(): Promisify<number[], Async>;
   getLocalIdsByGuids(guids: string[]): Promisify<(number | null)[], Async>;
   getGuidsByLocalIds(localIds: number[]): Promisify<(string | null)[], Async>;
   getLocalIdsFromItemIds(itemIds: Iterable<number>): Promisify<number[], Async>;
-}
-
-/**
- * Item-level queries — geometry presence, categories, children, data,
- * and arbitrary attribute/relation predicates.
- */
-export interface IItemsQuery<Async extends boolean> {
-  /**
-   * MISALIGNMENT: FragmentsModel's `DataManager` maps the raw local IDs into
-   * `Item[]` objects; SingleThreaded and VirtualFragmentsModel return `number[]`.
-   */
   getItemsIdsWithGeometry(): Promisify<number[], Async>;
   getItemsOfCategories(
     categories: RegExp[],
@@ -81,36 +66,6 @@ export interface IItemsQuery<Async extends boolean> {
     params: ItemsQueryParams,
     config?: ItemsQueryConfig,
   ): Promisify<number[], Async>;
-}
-
-/** Mesh geometry extraction, draw-chunk lookup, and cross-section computation. */
-export interface IModelGeometry<Async extends boolean> {
-  getItemsGeometry(
-    localIds: number[],
-    lod?: CurrentLod,
-  ): Promisify<MeshData[][], Async>;
-  getItemDrawChunks(localIds: Iterable<number>): Promisify<DrawChunk[], Async>;
-  getSection(
-    plane: THREE.Plane,
-    localIds?: number[],
-  ): Promisify<ModelSection, Async>;
-}
-
-/** Spatial positions and world-space coordinates. */
-export interface ICoordinatesHelper<Async extends boolean> {
-  getPositions(
-    localIds?: number[],
-  ): Promisify<{ x: number; y: number; z: number }[], Async>;
-  getCoordinates(): Promisify<THREE.Matrix3Tuple, Async>;
-}
-
-/** Binary serialization of the full model or an item subset. */
-export interface IModelSerializer<Async extends boolean> {
-  getBuffer(raw?: boolean): Promisify<ArrayBuffer | Uint8Array, Async>;
-  getSubsetBuffer(
-    localIds: number[],
-    raw?: boolean,
-  ): Promisify<ArrayBuffer | Uint8Array, Async>;
 }
 
 /**
@@ -142,7 +97,23 @@ export interface IRawModelData<Async extends boolean> {
   getGlobalTranformsIdsOfItems(ids: number[]): Promisify<number[], Async>;
 }
 
-/** User-defined per-model indexes (see the `ModelIndex` schema). */
+export interface IModelGeometry<Async extends boolean> {
+  getItemsGeometry(
+    localIds: number[],
+    lod?: CurrentLod,
+  ): Promisify<MeshData[][], Async>;
+  getItemDrawChunks(localIds: Iterable<number>): Promisify<DrawChunk[], Async>;
+  getSection(
+    plane: THREE.Plane,
+    localIds?: number[],
+  ): Promisify<ModelSection, Async>;
+  getPositions(
+    localIds?: number[],
+  ): Promisify<{ x: number; y: number; z: number }[], Async>;
+  getCoordinates(): Promisify<THREE.Matrix3Tuple, Async>;
+}
+
+/** User-defined indexes, see {@link VirtualIndexesController}. */
 export interface IModelIndex<Async extends boolean> {
   getIndexNames(): Promisify<string[], Async>;
   getIndexInfo(name: string): Promisify<IndexInfo | null, Async>;
@@ -170,50 +141,21 @@ export interface IModelIndex<Async extends boolean> {
   ): Promisify<IndexArrayType<V> | null, Async>;
 }
 
-/**
- * Common contract for both model variants, parameterized by `Async`:
- *  - `IFragmentsModel<false>` — synchronous variant ({@link SingleThreadedFragmentsModel})
- *  - `IFragmentsModel<true>`  — asynchronous variant ({@link FragmentsModel})
- *
- * ---
- * ### Misalignments — methods present in one class but absent (or internal) in the other
- *
- * **In `FragmentsModel` only (missing from `SingleThreadedFragmentsModel`):**
- * - `getGuids()` — VirtualFragmentsModel exposes this but SingleThreaded does not.
- * - `getItemsWithGeometryCategories()` — same situation.
- * - `getItemsIdsWithGeometry()` — FragmentsModel only.
- * - `getCoordinationMatrix()` — FragmentsModel only.
- * - `getMergedBox()` / `getBoxes()` — FragmentsModel only.
- * - `getAlignments()` / `getHorizontalAlignments()` / `getVerticalAlignments()` / `getAlignmentStyles()` — FragmentsModel only.
- * - `getGrids()` / `getGridMaterial()` / `setGridMaterial()` / `getGridLabelMaterial()` / `setGridLabelMaterial()` — FragmentsModel only.
- * - `useCamera()` / `setLodMode()` — FragmentsModel only.
- * - `raycast()` / `raycastAll()` / `raycastWithSnapping()` / `rectangleRaycast()` — FragmentsModel only.
- * - `setVisible()` / `toggleVisible()` / `resetVisible()` / `getVisible()` / `getItemsByVisibility()` — FragmentsModel only.
- * - `highlight()` / `setColor()` / `resetColor()` / `setOpacity()` / `resetOpacity()` — FragmentsModel only.
- * - `getHighlight()` / `resetHighlight()` / `getHighlightItemIds()` — FragmentsModel only.
- * - `getItemsMaterialDefinition()` — FragmentsModel only.
- * - `getAttributesUniqueValues()` — FragmentsModel only.
- * - `getEditedElements()` — FragmentsModel only.
- * - `getItemsVolume()` — FragmentsModel only.
- * - `getAttributeNames()` / `getAttributeValues()` / `getAttributeTypes()` / `getRelationNames()` — FragmentsModel only.
- * - `getGeometries()` — FragmentsModel only.
- * - `getItem()` — FragmentsModel only.
- *
- * **In `SingleThreadedFragmentsModel` only (absent or internal in `FragmentsModel`):**
- * - `edit()` — public in SingleThreaded; `FragmentsModel` exposes `_edit()` (internal) and routes edits through the `Editor` class.
- * - `reset()` / `save()` — same; `_reset()` / `_save()` are internal in FragmentsModel.
- * - `undo()` / `redo()` — SingleThreaded only; no equivalent in FragmentsModel.
- * - `getRequests()` / `setRequests()` / `selectRequest()` — SingleThreaded only; `_getRequests()` etc. are internal in FragmentsModel.
- */
+/** Binary serialization of the full model or an item subset. */
+export interface IModelSerializer<Async extends boolean> {
+  getBuffer(raw?: boolean): Promisify<ArrayBuffer | Uint8Array, Async>;
+  getSubsetBuffer(
+    localIds: number[],
+    raw?: boolean,
+  ): Promisify<ArrayBuffer | Uint8Array, Async>;
+}
+
 export interface IFragmentsModel<Async extends boolean = false>
-  extends IModelIndex<Async>,
-    ICoordinatesHelper<Async>,
-    IModelProperties<Async>,
-    IModelIds<Async>,
-    IItemsQuery<Async>,
+  extends IModelData<Async>,
+    IRawModelData<Async>,
     IModelGeometry<Async>,
-    IModelSerializer<Async>,
-    IRawModelData<Async> {
+    IModelIndex<Async>,
+    IModelSerializer<Async> {
   readonly modelId: string;
   dispose(): Promisify<void, Async>;
 }

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
@@ -1,0 +1,234 @@
+import * as THREE from "three";
+import {
+  RawGlobalTransformData,
+  RawItemData,
+  RawMaterial,
+  RawRelationData,
+  RawRepresentation,
+  RawSample,
+  RawTransformData,
+} from "../../../Utils";
+import {
+  CRSData,
+  CurrentLod,
+  Identifier,
+  IndexArrayType,
+  IndexEntry,
+  IndexInfo,
+  ItemData,
+  ItemsDataConfig,
+  ItemsQueryConfig,
+  ItemsQueryParams,
+  MeshData,
+  ModelSection,
+  SpatialTreeItem,
+} from "./model-types";
+
+type Promisify<T, Async extends boolean> = Async extends true ? Promise<T> : T;
+
+/**
+ * Per-tile index-buffer chunk returned by {@link IFragmentsModel.getItemDrawChunks}.
+ * `position` and `size` are parallel arrays: start index and count for each
+ * contiguous run of vertices belonging to the queried items in this tile's
+ * index buffer.
+ */
+export type DrawChunk = {
+  tileId: number;
+  position: Uint32Array;
+  size: Uint32Array;
+};
+
+export interface ICoordinatesHelper<Async extends boolean> {
+  getPositions(
+    localIds?: number[],
+  ): Promisify<{ x: number; y: number; z: number }[], Async>;
+  getCoordinates(): Promisify<THREE.Matrix3Tuple, Async>;
+}
+
+export interface IModelIndex<Async extends boolean> {
+  getIndexNames(): Promisify<string[], Async>;
+
+  getIndexInfo(name: string): Promisify<IndexInfo | null, Async>;
+
+  getIndexKeys<K extends string | number>(
+    name: string,
+  ): Promisify<IndexArrayType<K> | null, Async>;
+
+  getIndexKey<K extends string | number>(
+    name: string,
+    index: number,
+  ): Promisify<K | null, Async>;
+
+  getIndexValues<V extends string | number>(
+    name: string,
+  ): Promisify<V[] | null, Async>;
+
+  hasIndexEntry<K extends string | number>(
+    name: string,
+    key: K,
+  ): Promisify<boolean, Async>;
+
+  getIndexEntry<K extends string | number, V extends IndexEntry>(
+    name: string,
+    key: K,
+  ): Promisify<V | null, Async>;
+
+  getInverseIndexEntry<K extends string | number, V extends string | number>(
+    name: string,
+    value: K,
+  ): Promisify<IndexArrayType<V> | null, Async>;
+}
+
+/**
+ * Common contract for both model variants, parameterized by `Async`:
+ *  - `IFragmentsModel<false>` — synchronous variant ({@link SingleThreadedFragmentsModel})
+ *  - `IFragmentsModel<true>`  — asynchronous variant ({@link FragmentsModel})
+ *
+ * ---
+ * ### Misalignments — methods present in one class but absent (or internal) in the other
+ *
+ * **In `FragmentsModel` only (missing from `SingleThreadedFragmentsModel`):**
+ * - `getGuids()` — VirtualFragmentsModel exposes this but SingleThreaded does not.
+ * - `getItemsWithGeometryCategories()` — same situation.
+ * - `getItemsIdsWithGeometry()` — FragmentsModel only.
+ * - `getCoordinationMatrix()` — FragmentsModel only.
+ * - `getMergedBox()` / `getBoxes()` — FragmentsModel only.
+ * - `getAlignments()` / `getHorizontalAlignments()` / `getVerticalAlignments()` / `getAlignmentStyles()` — FragmentsModel only.
+ * - `getGrids()` / `getGridMaterial()` / `setGridMaterial()` / `getGridLabelMaterial()` / `setGridLabelMaterial()` — FragmentsModel only.
+ * - `useCamera()` / `setLodMode()` — FragmentsModel only.
+ * - `raycast()` / `raycastAll()` / `raycastWithSnapping()` / `rectangleRaycast()` — FragmentsModel only.
+ * - `setVisible()` / `toggleVisible()` / `resetVisible()` / `getVisible()` / `getItemsByVisibility()` — FragmentsModel only.
+ * - `highlight()` / `setColor()` / `resetColor()` / `setOpacity()` / `resetOpacity()` — FragmentsModel only.
+ * - `getHighlight()` / `resetHighlight()` / `getHighlightItemIds()` — FragmentsModel only.
+ * - `getItemsMaterialDefinition()` — FragmentsModel only.
+ * - `getAttributesUniqueValues()` — FragmentsModel only.
+ * - `getEditedElements()` — FragmentsModel only.
+ * - `getItemsVolume()` — FragmentsModel only.
+ * - `getAttributeNames()` / `getAttributeValues()` / `getAttributeTypes()` / `getRelationNames()` — FragmentsModel only.
+ * - `getGeometries()` — FragmentsModel only.
+ * - `getItem()` — FragmentsModel only.
+ *
+ * **In `SingleThreadedFragmentsModel` only (absent or internal in `FragmentsModel`):**
+ * - `edit()` — public in SingleThreaded; `FragmentsModel` exposes `_edit()` (internal) and routes edits through the `Editor` class.
+ * - `reset()` / `save()` — same; `_reset()` / `_save()` are internal in FragmentsModel.
+ * - `undo()` / `redo()` — SingleThreaded only; no equivalent in FragmentsModel.
+ * - `getRequests()` / `setRequests()` / `selectRequest()` — SingleThreaded only; `_getRequests()` etc. are internal in FragmentsModel.
+ *
+ * **Signature discrepancies:**
+ * - `getItemsData`: SingleThreaded declares `ids: number[]`; FragmentsModel uses the broader `ids: Identifier[]` (`string | number`).
+ * - `getItemsWithGeometry`: SingleThreaded / VirtualFragmentsModel return local-ID arrays (`number[]`);
+ *   FragmentsModel enriches them into `Item[]` via `DataManager`.
+ * - `*Ids()` methods (`getMaterialsIds`, `getRepresentationsIds`, etc.): the underlying
+ *   `applyChangesToIds` helper has a return type of `number[] | Uint32Array | Set<number>`
+ *   because TypeScript cannot prove the `actions: EditRequest[]` branch is always taken.
+ *   The interface uses `number[]` as the intended type; TypeScript will flag any implementation
+ *   that leaks the wider union.
+ * - `getSection`: always returns `Promise<ModelSection>` in both variants because
+ *   `VirtualFragmentsModel.getSection` is async — the `Async` generic does not apply.
+ */
+export interface IFragmentsModel<Async extends boolean = false>
+  extends ICoordinatesHelper<Async>,
+    IModelIndex<Async> {
+  readonly modelId: string;
+
+  // ---------------------------------------------------------------------------
+  // Spatial structure & properties
+  // ---------------------------------------------------------------------------
+
+  getSpatialStructure(): Promisify<SpatialTreeItem, Async>;
+  getCategories(): Promisify<string[], Async>;
+  getMetadata<T extends Record<string, any>>(): Promisify<T, Async>;
+  getCRS(): Promisify<CRSData | null, Async>;
+  getMaxLocalId(): Promisify<number, Async>;
+  getLocalIds(): Promisify<number[], Async>;
+  getLocalIdsByGuids(guids: string[]): Promisify<(number | null)[], Async>;
+  getGuidsByLocalIds(localIds: number[]): Promisify<(string | null)[], Async>;
+  getLocalIdsFromItemIds(itemIds: Iterable<number>): Promisify<number[], Async>;
+
+  // ---------------------------------------------------------------------------
+  // Items
+  // ---------------------------------------------------------------------------
+
+  /**
+   * MISALIGNMENT: FragmentsModel's `DataManager` maps the raw local IDs into
+   * `Item[]` objects; SingleThreaded and VirtualFragmentsModel return `number[]`.
+   */
+  getItemsWithGeometry(): Promisify<number[], Async>;
+  getItemsOfCategories(
+    categories: RegExp[],
+  ): Promisify<Record<string, number[]>, Async>;
+  getItemsChildren(ids: Identifier[]): Promisify<number[], Async>;
+  /**
+   * MISALIGNMENT: SingleThreaded declares `ids: number[]`; FragmentsModel uses
+   * the broader `ids: Identifier[]` (`string | number`).
+   */
+  getItemsData(
+    ids: Identifier[],
+    config?: Partial<ItemsDataConfig>,
+  ): Promisify<ItemData[], Async>;
+  getItemsByQuery(
+    params: ItemsQueryParams,
+    config?: ItemsQueryConfig,
+  ): Promisify<number[], Async>;
+
+  // ---------------------------------------------------------------------------
+  // Geometry & positions
+  // ---------------------------------------------------------------------------
+
+  getItemsGeometry(
+    localIds: number[],
+    lod?: CurrentLod,
+  ): Promisify<MeshData[][], Async>;
+  getItemDrawChunks(localIds: Iterable<number>): Promisify<DrawChunk[], Async>;
+  /**
+   * Always returns `Promise<ModelSection>` regardless of `Async` because
+   * `VirtualFragmentsModel.getSection` is inherently async in both variants.
+   */
+  getSection(
+    plane: THREE.Plane,
+    localIds?: number[],
+  ): Promisify<ModelSection, Async>;
+
+  // ---------------------------------------------------------------------------
+  // Serialization
+  // ---------------------------------------------------------------------------
+
+  getBuffer(raw?: boolean): Promisify<ArrayBuffer | Uint8Array, Async>;
+  getSubsetBuffer(
+    localIds: number[],
+    raw?: boolean,
+  ): Promisify<ArrayBuffer | Uint8Array, Async>;
+
+  // ---------------------------------------------------------------------------
+  // Raw model data (materials, transforms, representations, samples)
+  // ---------------------------------------------------------------------------
+
+  getMaterialsIds(): Promisify<number[], Async>;
+  getMaterials(
+    ids?: Iterable<number>,
+  ): Promisify<Map<number, RawMaterial>, Async>;
+  getRepresentationsIds(): Promisify<number[], Async>;
+  getRepresentations(
+    ids?: Iterable<number>,
+  ): Promisify<Map<number, RawRepresentation>, Async>;
+  getLocalTransformsIds(): Promisify<number[], Async>;
+  getLocalTransforms(
+    ids?: Iterable<number>,
+  ): Promisify<Map<number, RawTransformData>, Async>;
+  getGlobalTransformsIds(): Promisify<number[], Async>;
+  getGlobalTransforms(
+    ids?: Iterable<number>,
+  ): Promisify<Map<number, RawGlobalTransformData>, Async>;
+  getSamplesIds(): Promisify<number[], Async>;
+  getSamples(ids?: Iterable<number>): Promisify<Map<number, RawSample>, Async>;
+  getItemsIds(): Promisify<number[], Async>;
+  getItems(ids?: Iterable<number>): Promisify<Map<number, RawItemData>, Async>;
+  getRelations(ids?: number[]): Promisify<Map<number, RawRelationData>, Async>;
+  getGlobalTranformsIdsOfItems(ids: number[]): Promisify<number[], Async>;
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  dispose(): Promisify<void, Async>;
+}

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
@@ -111,7 +111,7 @@ export interface IModelGeometry<Async extends boolean> {
   getPositions(
     localIds?: number[],
   ): Promisify<{ x: number; y: number; z: number }[], Async>;
-  getCoordinates(): Promisify<THREE.Matrix3Tuple, Async>;
+  getCoordinates(): Promisify<number[], Async>;
 }
 
 /** User-defined indexes, see {@link VirtualIndexesController}. */

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model-interface.ts
@@ -38,6 +38,65 @@ export type DrawChunk = {
   size: Uint32Array;
 };
 
+/** Model metadata, spatial structure, categories, and CRS. */
+export interface IModelProperties<Async extends boolean> {
+  getSpatialStructure(): Promisify<SpatialTreeItem, Async>;
+  getCategories(): Promisify<string[], Async>;
+  getMetadata<T extends Record<string, any>>(): Promisify<T, Async>;
+  getCRS(): Promisify<CRSData | null, Async>;
+}
+
+/** Local-ID / GUID / item-ID translation and enumeration. */
+export interface IModelIds<Async extends boolean> {
+  getMaxLocalId(): Promisify<number, Async>;
+  getLocalIds(): Promisify<number[], Async>;
+  getLocalIdsByGuids(guids: string[]): Promisify<(number | null)[], Async>;
+  getGuidsByLocalIds(localIds: number[]): Promisify<(string | null)[], Async>;
+  getLocalIdsFromItemIds(itemIds: Iterable<number>): Promisify<number[], Async>;
+}
+
+/**
+ * Item-level queries — geometry presence, categories, children, data,
+ * and arbitrary attribute/relation predicates.
+ */
+export interface IItemsQuery<Async extends boolean> {
+  /**
+   * MISALIGNMENT: FragmentsModel's `DataManager` maps the raw local IDs into
+   * `Item[]` objects; SingleThreaded and VirtualFragmentsModel return `number[]`.
+   */
+  getItemsWithGeometry(): Promisify<number[], Async>;
+  getItemsOfCategories(
+    categories: RegExp[],
+  ): Promisify<Record<string, number[]>, Async>;
+  getItemsChildren(ids: Identifier[]): Promisify<number[], Async>;
+  /**
+   * MISALIGNMENT: SingleThreaded declares `ids: number[]`; FragmentsModel uses
+   * the broader `ids: Identifier[]` (`string | number`).
+   */
+  getItemsData(
+    ids: Identifier[],
+    config?: Partial<ItemsDataConfig>,
+  ): Promisify<ItemData[], Async>;
+  getItemsByQuery(
+    params: ItemsQueryParams,
+    config?: ItemsQueryConfig,
+  ): Promisify<number[], Async>;
+}
+
+/** Mesh geometry extraction, draw-chunk lookup, and cross-section computation. */
+export interface IModelGeometry<Async extends boolean> {
+  getItemsGeometry(
+    localIds: number[],
+    lod?: CurrentLod,
+  ): Promisify<MeshData[][], Async>;
+  getItemDrawChunks(localIds: Iterable<number>): Promisify<DrawChunk[], Async>;
+  getSection(
+    plane: THREE.Plane,
+    localIds?: number[],
+  ): Promisify<ModelSection, Async>;
+}
+
+/** Spatial positions and world-space coordinates. */
 export interface ICoordinatesHelper<Async extends boolean> {
   getPositions(
     localIds?: number[],
@@ -45,34 +104,66 @@ export interface ICoordinatesHelper<Async extends boolean> {
   getCoordinates(): Promisify<THREE.Matrix3Tuple, Async>;
 }
 
+/** Binary serialization of the full model or an item subset. */
+export interface IModelSerializer<Async extends boolean> {
+  getBuffer(raw?: boolean): Promisify<ArrayBuffer | Uint8Array, Async>;
+  getSubsetBuffer(
+    localIds: number[],
+    raw?: boolean,
+  ): Promisify<ArrayBuffer | Uint8Array, Async>;
+}
+
+/**
+ * Low-level access to the FlatBuffer tables: materials, representations,
+ * transforms, samples, items, and relations.
+ */
+export interface IRawModelData<Async extends boolean> {
+  getMaterialsIds(): Promisify<number[], Async>;
+  getMaterials(
+    ids?: Iterable<number>,
+  ): Promisify<Map<number, RawMaterial>, Async>;
+  getRepresentationsIds(): Promisify<number[], Async>;
+  getRepresentations(
+    ids?: Iterable<number>,
+  ): Promisify<Map<number, RawRepresentation>, Async>;
+  getLocalTransformsIds(): Promisify<number[], Async>;
+  getLocalTransforms(
+    ids?: Iterable<number>,
+  ): Promisify<Map<number, RawTransformData>, Async>;
+  getGlobalTransformsIds(): Promisify<number[], Async>;
+  getGlobalTransforms(
+    ids?: Iterable<number>,
+  ): Promisify<Map<number, RawGlobalTransformData>, Async>;
+  getSamplesIds(): Promisify<number[], Async>;
+  getSamples(ids?: Iterable<number>): Promisify<Map<number, RawSample>, Async>;
+  getItemsIds(): Promisify<number[], Async>;
+  getItems(ids?: Iterable<number>): Promisify<Map<number, RawItemData>, Async>;
+  getRelations(ids?: number[]): Promisify<Map<number, RawRelationData>, Async>;
+  getGlobalTranformsIdsOfItems(ids: number[]): Promisify<number[], Async>;
+}
+
+/** User-defined per-model indexes (see the `ModelIndex` schema). */
 export interface IModelIndex<Async extends boolean> {
   getIndexNames(): Promisify<string[], Async>;
-
   getIndexInfo(name: string): Promisify<IndexInfo | null, Async>;
-
   getIndexKeys<K extends string | number>(
     name: string,
   ): Promisify<IndexArrayType<K> | null, Async>;
-
   getIndexKey<K extends string | number>(
     name: string,
     index: number,
   ): Promisify<K | null, Async>;
-
   getIndexValues<V extends string | number>(
     name: string,
   ): Promisify<V[] | null, Async>;
-
   hasIndexEntry<K extends string | number>(
     name: string,
     key: K,
   ): Promisify<boolean, Async>;
-
   getIndexEntry<K extends string | number, V extends IndexEntry>(
     name: string,
     key: K,
   ): Promisify<V | null, Async>;
-
   getInverseIndexEntry<K extends string | number, V extends string | number>(
     name: string,
     value: K,
@@ -113,122 +204,16 @@ export interface IModelIndex<Async extends boolean> {
  * - `reset()` / `save()` — same; `_reset()` / `_save()` are internal in FragmentsModel.
  * - `undo()` / `redo()` — SingleThreaded only; no equivalent in FragmentsModel.
  * - `getRequests()` / `setRequests()` / `selectRequest()` — SingleThreaded only; `_getRequests()` etc. are internal in FragmentsModel.
- *
- * **Signature discrepancies:**
- * - `getItemsData`: SingleThreaded declares `ids: number[]`; FragmentsModel uses the broader `ids: Identifier[]` (`string | number`).
- * - `getItemsWithGeometry`: SingleThreaded / VirtualFragmentsModel return local-ID arrays (`number[]`);
- *   FragmentsModel enriches them into `Item[]` via `DataManager`.
- * - `*Ids()` methods (`getMaterialsIds`, `getRepresentationsIds`, etc.): the underlying
- *   `applyChangesToIds` helper has a return type of `number[] | Uint32Array | Set<number>`
- *   because TypeScript cannot prove the `actions: EditRequest[]` branch is always taken.
- *   The interface uses `number[]` as the intended type; TypeScript will flag any implementation
- *   that leaks the wider union.
- * - `getSection`: always returns `Promise<ModelSection>` in both variants because
- *   `VirtualFragmentsModel.getSection` is async — the `Async` generic does not apply.
  */
 export interface IFragmentsModel<Async extends boolean = false>
-  extends ICoordinatesHelper<Async>,
-    IModelIndex<Async> {
+  extends IModelIndex<Async>,
+    ICoordinatesHelper<Async>,
+    IModelProperties<Async>,
+    IModelIds<Async>,
+    IItemsQuery<Async>,
+    IModelGeometry<Async>,
+    IModelSerializer<Async>,
+    IRawModelData<Async> {
   readonly modelId: string;
-
-  // ---------------------------------------------------------------------------
-  // Spatial structure & properties
-  // ---------------------------------------------------------------------------
-
-  getSpatialStructure(): Promisify<SpatialTreeItem, Async>;
-  getCategories(): Promisify<string[], Async>;
-  getMetadata<T extends Record<string, any>>(): Promisify<T, Async>;
-  getCRS(): Promisify<CRSData | null, Async>;
-  getMaxLocalId(): Promisify<number, Async>;
-  getLocalIds(): Promisify<number[], Async>;
-  getLocalIdsByGuids(guids: string[]): Promisify<(number | null)[], Async>;
-  getGuidsByLocalIds(localIds: number[]): Promisify<(string | null)[], Async>;
-  getLocalIdsFromItemIds(itemIds: Iterable<number>): Promisify<number[], Async>;
-
-  // ---------------------------------------------------------------------------
-  // Items
-  // ---------------------------------------------------------------------------
-
-  /**
-   * MISALIGNMENT: FragmentsModel's `DataManager` maps the raw local IDs into
-   * `Item[]` objects; SingleThreaded and VirtualFragmentsModel return `number[]`.
-   */
-  getItemsWithGeometry(): Promisify<number[], Async>;
-  getItemsOfCategories(
-    categories: RegExp[],
-  ): Promisify<Record<string, number[]>, Async>;
-  getItemsChildren(ids: Identifier[]): Promisify<number[], Async>;
-  /**
-   * MISALIGNMENT: SingleThreaded declares `ids: number[]`; FragmentsModel uses
-   * the broader `ids: Identifier[]` (`string | number`).
-   */
-  getItemsData(
-    ids: Identifier[],
-    config?: Partial<ItemsDataConfig>,
-  ): Promisify<ItemData[], Async>;
-  getItemsByQuery(
-    params: ItemsQueryParams,
-    config?: ItemsQueryConfig,
-  ): Promisify<number[], Async>;
-
-  // ---------------------------------------------------------------------------
-  // Geometry & positions
-  // ---------------------------------------------------------------------------
-
-  getItemsGeometry(
-    localIds: number[],
-    lod?: CurrentLod,
-  ): Promisify<MeshData[][], Async>;
-  getItemDrawChunks(localIds: Iterable<number>): Promisify<DrawChunk[], Async>;
-  /**
-   * Always returns `Promise<ModelSection>` regardless of `Async` because
-   * `VirtualFragmentsModel.getSection` is inherently async in both variants.
-   */
-  getSection(
-    plane: THREE.Plane,
-    localIds?: number[],
-  ): Promisify<ModelSection, Async>;
-
-  // ---------------------------------------------------------------------------
-  // Serialization
-  // ---------------------------------------------------------------------------
-
-  getBuffer(raw?: boolean): Promisify<ArrayBuffer | Uint8Array, Async>;
-  getSubsetBuffer(
-    localIds: number[],
-    raw?: boolean,
-  ): Promisify<ArrayBuffer | Uint8Array, Async>;
-
-  // ---------------------------------------------------------------------------
-  // Raw model data (materials, transforms, representations, samples)
-  // ---------------------------------------------------------------------------
-
-  getMaterialsIds(): Promisify<number[], Async>;
-  getMaterials(
-    ids?: Iterable<number>,
-  ): Promisify<Map<number, RawMaterial>, Async>;
-  getRepresentationsIds(): Promisify<number[], Async>;
-  getRepresentations(
-    ids?: Iterable<number>,
-  ): Promisify<Map<number, RawRepresentation>, Async>;
-  getLocalTransformsIds(): Promisify<number[], Async>;
-  getLocalTransforms(
-    ids?: Iterable<number>,
-  ): Promisify<Map<number, RawTransformData>, Async>;
-  getGlobalTransformsIds(): Promisify<number[], Async>;
-  getGlobalTransforms(
-    ids?: Iterable<number>,
-  ): Promisify<Map<number, RawGlobalTransformData>, Async>;
-  getSamplesIds(): Promisify<number[], Async>;
-  getSamples(ids?: Iterable<number>): Promisify<Map<number, RawSample>, Async>;
-  getItemsIds(): Promisify<number[], Async>;
-  getItems(ids?: Iterable<number>): Promisify<Map<number, RawItemData>, Async>;
-  getRelations(ids?: number[]): Promisify<Map<number, RawRelationData>, Async>;
-  getGlobalTranformsIdsOfItems(ids: number[]): Promisify<number[], Async>;
-
-  // ---------------------------------------------------------------------------
-  // Lifecycle
-  // ---------------------------------------------------------------------------
-
   dispose(): Promisify<void, Async>;
 }

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
@@ -5,6 +5,7 @@ import {
   BIMMesh,
   CurrentLod,
   Identifier,
+  IndexEntry,
   ItemInformationType,
   ItemsDataConfig,
   ItemSelectionType,
@@ -19,7 +20,6 @@ import {
   SelectionInputType,
   SnappingRaycastData,
   VirtualModelConfig,
-  IndexEntry,
 } from "./model-types";
 
 import { FragmentsConnection } from "../multithreading/fragments-connection";
@@ -33,6 +33,7 @@ import { BoxManager } from "./box-manager";
 import { CoordinatesManager } from "./coordinates-manager";
 import { DataManager } from "./data-manager";
 import { EditManager } from "./edit-manager";
+import { IFragmentsModel } from "./fragments-model-interface";
 import { GridsConfig, GridsManager } from "./grids-manager";
 import { HighlightManager } from "./highlight-manager";
 import { ItemsManager } from "./items-manager";
@@ -46,7 +47,7 @@ import { VisibilityManager } from "./visibility-manager";
 /**
  * The main class for managing a 3D model loaded from a fragments file. Handles geometry, materials, visibility, highlighting, sections, and more. This class orchestrates multiple specialized managers to handle different aspects of the model like mesh management, item data, raycasting, etc. It maintains the overall state and provides the main interface for interacting with the model. The model data is loaded and processed asynchronously across multiple threads.
  */
-export class FragmentsModel {
+export class FragmentsModel implements IFragmentsModel<true> {
   /**
    * A map of attribute changes that have occurred in the model.
    * The key is the local ID of the item, and the value is the change.
@@ -273,7 +274,7 @@ export class FragmentsModel {
   /**
    * Get the spatial structure of the model.
    */
-  async getSpatialStructure() {
+  getSpatialStructure() {
     return this._dataManager.getSpatialStructure(this);
   }
 
@@ -281,7 +282,7 @@ export class FragmentsModel {
    * Get the local IDs corresponding to the specified GUIDs.
    * @param guids - Array of GUIDs to look up.
    */
-  async getLocalIdsByGuids(guids: string[]) {
+  getLocalIdsByGuids(guids: string[]) {
     return this._dataManager.getLocalIdsByGuids(this, guids);
   }
 
@@ -291,14 +292,14 @@ export class FragmentsModel {
    * per-vertex `id` attribute and need to map back to the public id
    * space.
    */
-  async getLocalIdsFromItemIds(itemIds: Iterable<number>) {
+  getLocalIdsFromItemIds(itemIds: Iterable<number>) {
     return this._dataManager.getLocalIdsFromItemIds(this, itemIds);
   }
 
   /**
    * Get all the categories of the model.
    */
-  async getCategories() {
+  getCategories() {
     return this._dataManager.getCategories(this);
   }
 
@@ -306,7 +307,7 @@ export class FragmentsModel {
    * Get the names of every user-defined index stored on this model. See the
    * `ModelIndex` schema for the supported shapes.
    */
-  async getIndexNames() {
+  getIndexNames() {
     return this._dataManager.getIndexNames(this);
   }
 
@@ -314,7 +315,7 @@ export class FragmentsModel {
    * Describe the shape of a named index without performing any lookups.
    * Returns `null` if no index with that name exists.
    */
-  async getIndexInfo(name: string) {
+  getIndexInfo(name: string) {
     return this._dataManager.getIndexInfo(this, name);
   }
 
@@ -323,7 +324,7 @@ export class FragmentsModel {
    * iteration) but valid for any mode. Number keys come back as a
    * `Uint32Array`, string keys as `string[]`.
    */
-  async getIndexKeys<K extends string | number>(name: string) {
+  getIndexKeys<K extends string | number>(name: string) {
     return this._dataManager.getIndexKeys<K>(this, name);
   }
 
@@ -345,7 +346,7 @@ export class FragmentsModel {
   /**
    * Test whether a key exists in the named index without resolving its value.
    */
-  async hasIndexEntry<K extends string | number>(name: string, key: K) {
+  hasIndexEntry<K extends string | number>(name: string, key: K) {
     return this._dataManager.hasIndexEntry(this, name, key);
   }
 
@@ -353,7 +354,7 @@ export class FragmentsModel {
    * Forward lookup of a single entry in the named index. The return shape
    * depends on the index mode (see {@link IndexEntry}).
    */
-  async getIndexEntry<K extends string | number, V extends IndexEntry>(
+  getIndexEntry<K extends string | number, V extends IndexEntry>(
     name: string,
     key: K,
   ) {
@@ -365,35 +366,35 @@ export class FragmentsModel {
    * returns every key that maps to `value`. The inverse map is built lazily
    * on first call and cached for the model's lifetime.
    */
-  async getInverseIndexEntry<
-    K extends string | number,
-    V extends string | number,
-  >(name: string, value: K) {
+  getInverseIndexEntry<K extends string | number, V extends string | number>(
+    name: string,
+    value: K,
+  ) {
     return this._dataManager.getInverseIndexEntry<K, V>(this, name, value);
   }
 
-  async getItemsWithGeometryCategories() {
+  getItemsWithGeometryCategories() {
     return this._dataManager.getItemsWithGeometryCategories(this);
   }
 
   /**
    * Get all the items of the model that have geometry.
    */
-  async getItemsWithGeometry() {
+  getItemsWithGeometry() {
     return this._dataManager.getItemsWithGeometry(this);
   }
 
   /**
    * Get all the items ids of the model that have geometry.
    */
-  async getItemsIdsWithGeometry() {
+  getItemsIdsWithGeometry() {
     return this._dataManager.getItemsIdsWithGeometry(this);
   }
 
   /**
    * Get the metadata of the model.
    */
-  async getMetadata<T extends Record<string, any> = Record<string, any>>() {
+  getMetadata<T extends Record<string, any> = Record<string, any>>() {
     return this._dataManager.getMetadata<T>(this);
   }
 
@@ -402,7 +403,7 @@ export class FragmentsModel {
    * Returns null if the source IFC file did not contain IFCPROJECTEDCRS
    * or IFCCOORDINATEREFERENCESYSTEM entities.
    */
-  async getCRS() {
+  getCRS() {
     return this._dataManager.getCRS(this);
   }
 
@@ -410,7 +411,7 @@ export class FragmentsModel {
    * Get the GUIDs corresponding to the specified local IDs.
    * @param localIds - Array of local IDs to look up.
    */
-  async getGuidsByLocalIds(localIds: number[]) {
+  getGuidsByLocalIds(localIds: number[]) {
     return this._dataManager.getGuidsByLocalIds(this, localIds);
   }
 
@@ -418,7 +419,7 @@ export class FragmentsModel {
    * Get the buffer of the model.
    * @param raw - Whether to get the raw buffer. If false, it will be compressed.
    */
-  async getBuffer(raw = false) {
+  getBuffer(raw = false) {
     return this._dataManager.getBuffer(this, raw);
   }
 
@@ -427,7 +428,7 @@ export class FragmentsModel {
    * @param localIds - The local IDs of the items to include.
    * @param raw - Whether to get the raw buffer. If false, it will be compressed.
    */
-  async getSubsetBuffer(localIds: number[], raw = false) {
+  getSubsetBuffer(localIds: number[], raw = false) {
     return this.threads.invoke(this.modelId, "getSubsetBuffer", [
       localIds,
       raw,
@@ -438,7 +439,7 @@ export class FragmentsModel {
    * Get all the items of the model that belong to the specified category.
    * @param category - The category to look up.
    */
-  async getItemsOfCategories(categories: RegExp[]) {
+  getItemsOfCategories(categories: RegExp[]) {
     return this._dataManager.getItemsOfCategories(this, categories);
   }
 
@@ -470,7 +471,7 @@ export class FragmentsModel {
    * @param config - Optional query configuration.
    * @returns A promise that resolves to the items matching the query.
    */
-  async getItemsByQuery(params: ItemsQueryParams, config?: ItemsQueryConfig) {
+  getItemsByQuery(params: ItemsQueryParams, config?: ItemsQueryConfig) {
     return this._dataManager.getItemsByQuery(this, params, config);
   }
 
@@ -493,11 +494,11 @@ export class FragmentsModel {
    * @param localIds - An array of local IDs for which the geometry data is requested.
    * @param lod - The level of detail for the geometry (optional).
    */
-  async getItemsGeometry(localIds: number[], lod = CurrentLod.GEOMETRY) {
+  getItemsGeometry(localIds: number[], lod = CurrentLod.GEOMETRY) {
     return this._editManager.getItemsGeometry(this, localIds, lod);
   }
 
-  async getGeometries(ids: number[]) {
+  getGeometries(ids: number[]) {
     return this._editManager.getGeometries(this, ids);
   }
 
@@ -582,7 +583,7 @@ export class FragmentsModel {
   /**
    * Get the maximum local ID of the model.
    */
-  async getMaxLocalId() {
+  getMaxLocalId() {
     return this._dataManager.getMaxLocalId(this);
   }
 
@@ -598,7 +599,7 @@ export class FragmentsModel {
    * Get the spatial structure children of the specified items.
    * @param ids - The IDs of the items to look up.
    */
-  async getItemsChildren(ids: Identifier[]) {
+  getItemsChildren(ids: Identifier[]) {
     return this._itemsManager.getItemsChildren(this, ids);
   }
 
@@ -630,7 +631,7 @@ export class FragmentsModel {
    *   },
    * });
    */
-  async getItemsData(ids: Identifier[], config?: Partial<ItemsDataConfig>) {
+  getItemsData(ids: Identifier[], config?: Partial<ItemsDataConfig>) {
     return this._itemsManager.getItemsData(this, ids, config);
   }
 
@@ -638,14 +639,14 @@ export class FragmentsModel {
    * Get the absolute positions of the specified items.
    * @param localIds - The local IDs of the items to look up.
    */
-  async getPositions(localIds?: number[]) {
+  getPositions(localIds?: number[]) {
     return this._coordinatesManager.getPositions(this, localIds);
   }
 
   /**
    * Gets coordinates of the model.
    */
-  async getCoordinates() {
+  getCoordinates() {
     return this._coordinatesManager.getCoordinates(this);
   }
 
@@ -655,7 +656,7 @@ export class FragmentsModel {
    * This method utilizes the `_coordinatesManager` to compute and return a
    * `THREE.Matrix4` object based on the original model coordinates.
    */
-  async getCoordinationMatrix() {
+  getCoordinationMatrix() {
     return this._coordinatesManager.getCoordinationMatrix(this);
   }
 
@@ -663,7 +664,7 @@ export class FragmentsModel {
    * Get the merged bounding box of the specified items.
    * @param localIds - The local IDs of the items to look up.
    */
-  async getMergedBox(localIds: number[]) {
+  getMergedBox(localIds: number[]) {
     return this._boxManager.getMergedBox(this, localIds);
   }
 
@@ -671,28 +672,28 @@ export class FragmentsModel {
    * Get the individual bounding boxes of the specified items.
    * @param localIds - The local IDs of the items to look up.
    */
-  async getBoxes(localIds?: number[]) {
+  getBoxes(localIds?: number[]) {
     return this._boxManager.getBoxes(this, localIds);
   }
 
   /**
    * Get the absolute alignments of the model (if any).
    */
-  async getAlignments() {
+  getAlignments() {
     return this._alignmentsManager.getAlignments();
   }
 
   /**
    * Get the horizontal alignments of the model (if any).
    */
-  async getHorizontalAlignments() {
+  getHorizontalAlignments() {
     return this._alignmentsManager.getHorizontalAlignments();
   }
 
   /**
    * Get the vertical alignments of the model (if any).
    */
-  async getVerticalAlignments() {
+  getVerticalAlignments() {
     return this._alignmentsManager.getVerticalAlignments();
   }
 
@@ -720,7 +721,7 @@ export class FragmentsModel {
    * All grid's descendants (`"axis"`, `"line"`, `"label"`) carry `userData.tag` (the axis label value)
    * and `userData.axis` (`"uAxes"`, `"vAxes"`, or `"wAxes"`).
    */
-  async getGrids(config?: GridsConfig) {
+  getGrids(config?: GridsConfig) {
     return this._gridsManager.getGrids(config);
   }
 
@@ -773,7 +774,7 @@ export class FragmentsModel {
    * Sets the LOD / culling mode of the model.
    * @param lodMode - The LOD / culling mode to set.
    */
-  async setLodMode(lodMode: LodMode) {
+  setLodMode(lodMode: LodMode) {
     return this._viewManager.setLodMode(this, lodMode);
   }
 
@@ -781,7 +782,7 @@ export class FragmentsModel {
    * Performs a rectangle raycast on the model.
    * @param data - The data of the rectangle raycast.
    */
-  async rectangleRaycast(data: RectangleRaycastData) {
+  rectangleRaycast(data: RectangleRaycastData) {
     return this._raycastManager.rectangleRaycast(this, this._meshManager, data);
   }
 
@@ -789,7 +790,7 @@ export class FragmentsModel {
    * Performs a raycast on the model.
    * @param data - The data of the raycast.
    */
-  async raycast(data: RaycastData) {
+  raycast(data: RaycastData) {
     return this._raycastManager.raycast(this, data);
   }
 
@@ -797,7 +798,7 @@ export class FragmentsModel {
    * Performs a raycast on the model and returns all the results.
    * @param data - The data of the raycast.
    */
-  async raycastAll(data: RaycastData) {
+  raycastAll(data: RaycastData) {
     return this._raycastManager.raycastAll(this, data);
   }
 
@@ -805,7 +806,7 @@ export class FragmentsModel {
    * Performs a raycast on the model with snapping.
    * @param data - The data of the raycast.
    */
-  async raycastWithSnapping(data: SnappingRaycastData) {
+  raycastWithSnapping(data: SnappingRaycastData) {
     return this._raycastManager.raycastWithSnapping(this, data);
   }
 
@@ -832,7 +833,7 @@ export class FragmentsModel {
    * Gets the items by visibility.
    * @param visible - Whether the items should be visible.
    */
-  async getItemsByVisibility(visible: boolean) {
+  getItemsByVisibility(visible: boolean) {
     return this._visibilityManager.getItemsByVisibility(this, visible);
   }
 
@@ -840,14 +841,14 @@ export class FragmentsModel {
    * Gets the items by visibility.
    * @param localIds - The local IDs of the items to get the visibility of.
    */
-  async getVisible(localIds: number[]) {
+  getVisible(localIds: number[]) {
     return this._visibilityManager.getVisible(this, localIds);
   }
 
   /**
    * Resets the visibility of all items.
    */
-  async resetVisible() {
+  resetVisible() {
     return this._visibilityManager.resetVisible(this);
   }
 
@@ -856,7 +857,7 @@ export class FragmentsModel {
    * @param localIds - The local IDs of the items to highlight. If undefined, all items will be highlighted.
    * @param highlightMaterial - The material to use for the highlight.
    */
-  async highlight(
+  highlight(
     localIds: number[] | undefined,
     highlightMaterial: MaterialDefinition,
   ) {
@@ -868,10 +869,7 @@ export class FragmentsModel {
    * @param localIds - The local IDs of the items to color. If undefined, all items will be colored.
    * @param color - The color to apply.
    */
-  async setColor(
-    localIds: number[] | undefined,
-    color: MaterialDefinition["color"],
-  ) {
+  setColor(localIds: number[] | undefined, color: MaterialDefinition["color"]) {
     return this._highlightManager.setColor(this, localIds, color);
   }
 
@@ -879,7 +877,7 @@ export class FragmentsModel {
    * Resets the color of the specified items to their original color while preserving other highlight properties (like opacity).
    * @param localIds - The local IDs of the items to reset color for. If undefined, all items will be affected.
    */
-  async resetColor(localIds: number[] | undefined) {
+  resetColor(localIds: number[] | undefined) {
     return this._highlightManager.resetColor(this, localIds);
   }
 
@@ -888,7 +886,7 @@ export class FragmentsModel {
    * @param localIds - The local IDs of the items to change opacity for. If undefined, all items will be affected.
    * @param opacity - The opacity to apply (0 to 1).
    */
-  async setOpacity(localIds: number[] | undefined, opacity: number) {
+  setOpacity(localIds: number[] | undefined, opacity: number) {
     return this._highlightManager.setOpacity(this, localIds, opacity);
   }
 
@@ -896,7 +894,7 @@ export class FragmentsModel {
    * Resets the opacity of the specified items to their original opacity while preserving other highlight properties (like color).
    * @param localIds - The local IDs of the items to reset opacity for. If undefined, all items will be affected.
    */
-  async resetOpacity(localIds: number[] | undefined) {
+  resetOpacity(localIds: number[] | undefined) {
     return this._highlightManager.resetOpacity(this, localIds);
   }
 
@@ -904,7 +902,7 @@ export class FragmentsModel {
    * Gets the highlight of the specified items.
    * @param localIds - The local IDs of the items to get the highlight of. If undefined, it will return the highlight of all items.
    */
-  async getHighlight(localIds?: number[]) {
+  getHighlight(localIds?: number[]) {
     return this._highlightManager.getHighlight(this, localIds);
   }
 
@@ -912,14 +910,14 @@ export class FragmentsModel {
    * Resets the highlight of the specified items.
    * @param localIds - The local IDs of the items to reset the highlight of. If undefined, it will reset the highlight of all items.
    */
-  async resetHighlight(localIds?: number[]) {
+  resetHighlight(localIds?: number[]) {
     return this._highlightManager.resetHighlight(this, localIds);
   }
 
   /**
    * Gets the item IDs of the items that are highlighted.
    */
-  async getHighlightItemIds() {
+  getHighlightItemIds() {
     return this._highlightManager.getHighlightItemIds(this);
   }
 
@@ -928,14 +926,14 @@ export class FragmentsModel {
    * @param plane - The plane to get the section of.
    * @param localIds - The local IDs of the items to get the section of. If undefined, it will return the section of all items.
    */
-  async getSection(plane: THREE.Plane, localIds?: number[]) {
+  getSection(plane: THREE.Plane, localIds?: number[]) {
     return this._sectionManager.getSection(this, plane, localIds);
   }
 
   /**
    * Gets all the materials IDs of the model.
    */
-  async getMaterialsIds() {
+  getMaterialsIds() {
     return this._editManager.getMaterialsIds(this);
   }
 
@@ -943,14 +941,14 @@ export class FragmentsModel {
    * Gets the materials of the model.
    * @param localIds - The local IDs of the materials to get. If undefined, it will return all materials.
    */
-  async getMaterials(localIds?: Iterable<number>) {
+  getMaterials(localIds?: Iterable<number>) {
     return this._editManager.getMaterials(this, localIds);
   }
 
   /**
    * Gets all the representations IDs of the model.
    */
-  async getRepresentationsIds() {
+  getRepresentationsIds() {
     return this._editManager.getRepresentationsIds(this);
   }
 
@@ -958,14 +956,14 @@ export class FragmentsModel {
    * Gets the representations of the model.
    * @param localIds - The local IDs of the representations to get. If undefined, it will return all representations.
    */
-  async getRepresentations(localIds?: Iterable<number>) {
+  getRepresentations(localIds?: Iterable<number>) {
     return this._editManager.getRepresentations(this, localIds);
   }
 
   /**
    * Gets all the local transforms IDs of the model.
    */
-  async getLocalTransformsIds() {
+  getLocalTransformsIds() {
     return this._editManager.getLocalTransformsIds(this);
   }
 
@@ -973,14 +971,14 @@ export class FragmentsModel {
    * Gets the local transforms of the model.
    * @param localIds - The local IDs of the local transforms to get. If undefined, it will return all local transforms.
    */
-  async getLocalTransforms(localIds?: Iterable<number>) {
+  getLocalTransforms(localIds?: Iterable<number>) {
     return this._editManager.getLocalTransforms(this, localIds);
   }
 
   /**
    * Gets all the global transforms IDs of the model.
    */
-  async getGlobalTransformsIds() {
+  getGlobalTransformsIds() {
     return this._editManager.getGlobalTransformsIds(this);
   }
 
@@ -988,14 +986,14 @@ export class FragmentsModel {
    * Gets the global transforms of the model.
    * @param localIds - The local IDs of the global transforms to get. If undefined, it will return all global transforms.
    */
-  async getGlobalTransforms(localIds?: Iterable<number>) {
+  getGlobalTransforms(localIds?: Iterable<number>) {
     return this._editManager.getGlobalTransforms(this, localIds);
   }
 
   /**
    * Gets all the samples IDs of the model.
    */
-  async getSamplesIds() {
+  getSamplesIds() {
     return this._editManager.getSamplesIds(this);
   }
 
@@ -1003,7 +1001,7 @@ export class FragmentsModel {
    * Gets the samples of the model.
    * @param localIds - The local IDs of the samples to get. If undefined, it will return all samples.
    */
-  async getSamples(localIds?: Iterable<number>) {
+  getSamples(localIds?: Iterable<number>) {
     return this._editManager.getSamples(this, localIds);
   }
 
@@ -1018,14 +1016,14 @@ export class FragmentsModel {
    * for each chunk to draw only the matching slices. No highlight
    * material slot is allocated; the call is read-only.
    */
-  async getItemDrawChunks(localIds: Iterable<number>) {
+  getItemDrawChunks(localIds: Iterable<number>) {
     return this._dataManager.getItemDrawChunks(this, localIds);
   }
 
   /**
    * Gets all the items IDs of the model.
    */
-  async getItemsIds() {
+  getItemsIds() {
     return this._editManager.getItemsIds(this);
   }
 
@@ -1033,7 +1031,7 @@ export class FragmentsModel {
    * Gets the items of the model.
    * @param localIds - The local IDs of the items to get. If undefined, it will return all items.
    */
-  async getItems(localIds?: Iterable<number>) {
+  getItems(localIds?: Iterable<number>) {
     return this._editManager.getItems(this, localIds);
   }
 
@@ -1041,7 +1039,7 @@ export class FragmentsModel {
    * Gets the relations of the model.
    * @param localIds - The local IDs of the relations to get. If undefined, it will return all relations.
    */
-  async getRelations(localIds?: number[]) {
+  getRelations(localIds?: number[]) {
     return this._editManager.getRelations(this, localIds);
   }
 
@@ -1049,14 +1047,14 @@ export class FragmentsModel {
    * Gets the global transforms IDs of the items of the model.
    * @param ids - The local IDs of the items to get the global transforms IDs of.
    */
-  async getGlobalTranformsIdsOfItems(ids: number[]) {
+  getGlobalTranformsIdsOfItems(ids: number[]) {
     return this._editManager.getGlobalTranformsIdsOfItems(this, ids);
   }
 
   /**
    * Gets the edited elements of the model.
    */
-  async getEditedElements() {
+  getEditedElements() {
     return this._editManager.getEditedElements(this);
   }
 
@@ -1069,10 +1067,7 @@ export class FragmentsModel {
    * @returns The computed result after processing the sequence of actions, or `null` if the result function is not found.
    * @experimental
    */
-  async getSequenced<
-    T extends ItemInformationType,
-    U extends ItemSelectionType,
-  >(
+  getSequenced<T extends ItemInformationType, U extends ItemSelectionType>(
     result: T,
     fromItems: U[],
     inputs?: {
@@ -1087,7 +1082,7 @@ export class FragmentsModel {
     await this._meshManager.requests.handleRequest(this._meshManager, request);
   }
 
-  async _getElements(localIds: Iterable<number>) {
+  _getElements(localIds: Iterable<number>) {
     return this._editManager.getElements(this, localIds);
   }
 
@@ -1096,7 +1091,7 @@ export class FragmentsModel {
    * `EditManager.getItemSnapData`. Internal — picker / SnapResolver
    * consume this. App code should keep using `_getElements` (localId).
    */
-  async _getItemSnapData(itemId: number) {
+  _getItemSnapData(itemId: number) {
     return this._editManager.getItemSnapData(this, itemId);
   }
 
@@ -1143,28 +1138,28 @@ export class FragmentsModel {
    * Internal method to edit the model. Don't use this directly.
    * @param requests - The requests to edit the model.
    */
-  async _edit(requests: EditRequest[]) {
+  _edit(requests: EditRequest[]) {
     return this._editManager.edit(this, requests);
   }
 
   /**
    * Internal method to reset the model. Don't use this directly.
    */
-  async _reset() {
+  _reset() {
     return this._editManager.reset(this);
   }
 
   /**
    * Internal method to save the model. Don't use this directly.
    */
-  async _save() {
+  _save() {
     return this._editManager.save(this);
   }
 
   /**
    * Internal method to get the requests of the model. Don't use this directly.
    */
-  async _getRequests() {
+  _getRequests() {
     return this._editManager.getRequests(this);
   }
 
@@ -1172,7 +1167,7 @@ export class FragmentsModel {
    * Internal method to set the requests of the model. Don't use this directly.
    * @param data - The data to set the requests of the model.
    */
-  async _setRequests(data: {
+  _setRequests(data: {
     requests?: EditRequest[];
     undoneRequests?: EditRequest[];
   }) {
@@ -1183,7 +1178,7 @@ export class FragmentsModel {
    * Internal method to select a request of the model. Don't use this directly.
    * @param index - The index of the request to select.
    */
-  async _selectRequest(index: number) {
+  _selectRequest(index: number) {
     return this._editManager.selectRequest(this, index);
   }
 }

--- a/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
+++ b/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
@@ -163,7 +163,7 @@ export class SingleThreadedFragmentsModel implements IFragmentsModel<false> {
   /**
    * Get all the items of the model that have geometry.
    */
-  getItemsWithGeometry() {
+  getItemsIdsWithGeometry() {
     return this._virtualModel.getItemsWithGeometry();
   }
 

--- a/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
+++ b/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
@@ -161,6 +161,13 @@ export class SingleThreadedFragmentsModel implements IFragmentsModel<false> {
   }
 
   /**
+   * @deprecated use {@link getItemsIdsWithGeometry}
+   */
+  getItemsWithGeometry() {
+    return this.getItemsIdsWithGeometry();
+  }
+
+  /**
    * Get all the items of the model that have geometry.
    */
   getItemsIdsWithGeometry() {

--- a/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
+++ b/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
@@ -262,6 +262,10 @@ export class SingleThreadedFragmentsModel implements IFragmentsModel<false> {
     return this._virtualModel.getItemsGeometry(localIds, lod);
   }
 
+  getItemsVolume(localIds: number[]) {
+    return this._virtualModel.getItemsVolume(localIds);
+  }
+
   /**
    * Query items based on specified parameters.
    * @param params - The query parameters.

--- a/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
+++ b/packages/fragments/src/FragmentsModels/src/single-threading/index.ts
@@ -1,5 +1,6 @@
-import * as THREE from "three";
 import pako from "pako";
+import * as THREE from "three";
+import { EditRequest } from "../../../Utils";
 import {
   CurrentLod,
   Identifier,
@@ -8,14 +9,14 @@ import {
   ItemsQueryConfig,
   ItemsQueryParams,
 } from "../model";
-import { VirtualFragmentsModel } from "../virtual-model/virtual-fragments-model";
-import { EditRequest } from "../../../Utils";
+import { IFragmentsModel } from "../model/fragments-model-interface";
 import { isRawBuffer } from "../utils/misc/buffer";
+import { VirtualFragmentsModel } from "../virtual-model/virtual-fragments-model";
 
 /**
  * The main class for managing a 3D model loaded from a fragments file in a single thread. It's designed for easy data querying in the backend, so all the 3D visualization logic is not present.
  */
-export class SingleThreadedFragmentsModel {
+export class SingleThreadedFragmentsModel implements IFragmentsModel<false> {
   private readonly _modelId: string;
   private _virtualModel: VirtualFragmentsModel;
 
@@ -77,7 +78,7 @@ export class SingleThreadedFragmentsModel {
    * Translate internal `itemId`s into user-facing `localId`s, preserving
    * order. See {@link VirtualFragmentsModel.getLocalIdsFromItemIds}.
    */
-  async getLocalIdsFromItemIds(itemIds: Iterable<number>) {
+  getLocalIdsFromItemIds(itemIds: Iterable<number>) {
     return this._virtualModel.getLocalIdsFromItemIds(itemIds);
   }
 
@@ -241,7 +242,7 @@ export class SingleThreadedFragmentsModel {
    * Get the absolute positions of the specified items.
    * @param localIds - The local IDs of the items to look up.
    */
-  getPositions(localIds: number[]) {
+  getPositions(localIds?: number[]) {
     return this._virtualModel.getPositions(localIds);
   }
 
@@ -275,21 +276,21 @@ export class SingleThreadedFragmentsModel {
    * @param plane - The plane to get the section of.
    * @param localIds - The local IDs of the items to get the section of. If undefined, it will return the section of all items.
    */
-  async getSection(plane: THREE.Plane, localIds?: number[]) {
+  getSection(plane: THREE.Plane, localIds?: number[]) {
     return this._virtualModel.getSection(plane, localIds);
   }
 
   /**
    * Get all the local IDs of the model.
    */
-  async getLocalIds() {
+  getLocalIds() {
     return this._virtualModel.getLocalIds();
   }
 
   /**
    * Gets all the materials IDs of the model.
    */
-  async getMaterialsIds() {
+  getMaterialsIds() {
     return this._virtualModel.getMaterialsIds();
   }
 
@@ -297,14 +298,14 @@ export class SingleThreadedFragmentsModel {
    * Gets the materials of the model.
    * @param localIds - The local IDs of the materials to get. If undefined, it will return all materials.
    */
-  async getMaterials(localIds?: Iterable<number>) {
+  getMaterials(localIds?: Iterable<number>) {
     return this._virtualModel.getMaterials(localIds);
   }
 
   /**
    * Gets all the representations IDs of the model.
    */
-  async getRepresentationsIds() {
+  getRepresentationsIds() {
     return this._virtualModel.getRepresentationsIds();
   }
 
@@ -312,14 +313,14 @@ export class SingleThreadedFragmentsModel {
    * Gets the representations of the model.
    * @param localIds - The local IDs of the representations to get. If undefined, it will return all representations.
    */
-  async getRepresentations(localIds?: Iterable<number>) {
+  getRepresentations(localIds?: Iterable<number>) {
     return this._virtualModel.getRepresentations(localIds);
   }
 
   /**
    * Gets all the local transforms IDs of the model.
    */
-  async getLocalTransformsIds() {
+  getLocalTransformsIds() {
     return this._virtualModel.getLocalTransformsIds();
   }
 
@@ -327,14 +328,14 @@ export class SingleThreadedFragmentsModel {
    * Gets the local transforms of the model.
    * @param localIds - The local IDs of the local transforms to get. If undefined, it will return all local transforms.
    */
-  async getLocalTransforms(localIds?: Iterable<number>) {
+  getLocalTransforms(localIds?: Iterable<number>) {
     return this._virtualModel.getLocalTransforms(localIds);
   }
 
   /**
    * Gets all the global transforms IDs of the model.
    */
-  async getGlobalTransformsIds() {
+  getGlobalTransformsIds() {
     return this._virtualModel.getGlobalTransformsIds();
   }
 
@@ -342,14 +343,14 @@ export class SingleThreadedFragmentsModel {
    * Gets the global transforms of the model.
    * @param localIds - The local IDs of the global transforms to get. If undefined, it will return all global transforms.
    */
-  async getGlobalTransforms(localIds?: Iterable<number>) {
+  getGlobalTransforms(localIds?: Iterable<number>) {
     return this._virtualModel.getGlobalTransforms(localIds);
   }
 
   /**
    * Gets all the samples IDs of the model.
    */
-  async getSamplesIds() {
+  getSamplesIds() {
     return this._virtualModel.getSamplesIds();
   }
 
@@ -357,7 +358,7 @@ export class SingleThreadedFragmentsModel {
    * Gets the samples of the model.
    * @param localIds - The local IDs of the samples to get. If undefined, it will return all samples.
    */
-  async getSamples(localIds?: Iterable<number>) {
+  getSamples(localIds?: Iterable<number>) {
     return this._virtualModel.getSamples(localIds);
   }
 
@@ -366,14 +367,14 @@ export class SingleThreadedFragmentsModel {
    * outline-style passes that share tile geometry and clip drawing to
    * just the outlined samples. See {@link VirtualFragmentsModel.getItemDrawChunks}.
    */
-  async getItemDrawChunks(localIds: Iterable<number>) {
+  getItemDrawChunks(localIds: Iterable<number>) {
     return this._virtualModel.getItemDrawChunks(localIds);
   }
 
   /**
    * Gets all the items IDs of the model.
    */
-  async getItemsIds() {
+  getItemsIds() {
     return this._virtualModel.getItemsIds();
   }
 
@@ -381,7 +382,7 @@ export class SingleThreadedFragmentsModel {
    * Gets the items of the model.
    * @param localIds - The local IDs of the items to get. If undefined, it will return all items.
    */
-  async getItems(localIds?: Iterable<number>) {
+  getItems(localIds?: Iterable<number>) {
     return this._virtualModel.getItems(localIds);
   }
 
@@ -389,7 +390,7 @@ export class SingleThreadedFragmentsModel {
    * Gets the relations of the model.
    * @param localIds - The local IDs of the relations to get. If undefined, it will return all relations.
    */
-  async getRelations(localIds?: number[]) {
+  getRelations(localIds?: number[]) {
     return this._virtualModel.getRelations(localIds);
   }
 
@@ -397,7 +398,7 @@ export class SingleThreadedFragmentsModel {
    * Gets the global transforms IDs of the items of the model.
    * @param ids - The local IDs of the items to get the global transforms IDs of.
    */
-  async getGlobalTranformsIdsOfItems(ids: number[]) {
+  getGlobalTranformsIdsOfItems(ids: number[]) {
     return this._virtualModel.getGlobalTranformsIdsOfItems(ids);
   }
 

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/alignments-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/alignments-controller.ts
@@ -12,7 +12,7 @@ export class AlignmentsController {
     this._fragments = virtualFragmentsModel;
   }
 
-  async getAlignments() {
+  getAlignments() {
     const allAlignments: AlignmentData[] = [];
 
     // TODO: Extend AlignmentDataItem to optionally have implicit geometry

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
@@ -1,5 +1,5 @@
-import * as THREE from "three";
 import { ByteBuffer } from "flatbuffers";
+import * as THREE from "three";
 
 import pako from "pako";
 
@@ -11,37 +11,39 @@ import {
 } from "three-mesh-bvh";
 
 import {
-  VirtualMaterialController,
-  VirtualTilesController,
-  VirtualPropertiesController,
-  RaycastController,
-  AlignmentsController,
-  ItemConfigController,
-  VirtualIndexesController,
-} from "./virtual-controllers";
-import {
-  MaterialDefinition,
-  SnappingClass,
-  VirtualModelConfig,
-  ItemSelectionType,
-  ItemInformationType,
-  Identifier,
-  ItemsQueryParams,
-  MeshData,
   AttributesUniqueValuesParams,
   CurrentLod,
-  ItemsQueryConfig,
+  Identifier,
+  IndexArrayType,
   IndexEntry,
   IndexInfo,
+  ItemInformationType,
+  ItemSelectionType,
+  ItemsQueryConfig,
+  ItemsQueryParams,
   LodMode,
-  IndexArrayType,
+  MaterialDefinition,
+  MeshData,
+  SnappingClass,
+  VirtualModelConfig,
 } from "../model/model-types";
+import {
+  AlignmentsController,
+  ItemConfigController,
+  RaycastController,
+  VirtualIndexesController,
+  VirtualMaterialController,
+  VirtualPropertiesController,
+  VirtualTilesController,
+} from "./virtual-controllers";
 
 import { VirtualBoxController } from "../bounding-boxes";
 
-import { Connection } from "../multithreading/connection";
 import { Model } from "../../../Schema";
+import { Connection } from "../multithreading/connection";
 
+import { EditRequest, EditRequestType, EditUtils } from "../../../Utils";
+import { GridsController } from "./virtual-controllers/grids-controller";
 import {
   CoordinatesHelper,
   GeometryHelper,
@@ -52,9 +54,7 @@ import {
   SequenceHelper,
   VisibilityHelper,
 } from "./virtual-helpers";
-import { EditRequest, EditRequestType, EditUtils } from "../../../Utils";
 import { TileData } from "./virtual-meshes";
-import { GridsController } from "./virtual-controllers/grids-controller";
 
 export class VirtualFragmentsModel {
   data: Model;
@@ -157,7 +157,10 @@ export class VirtualFragmentsModel {
     name: string,
     value: K,
   ): IndexArrayType<V> | null {
-    return this.indexes.getInverseEntry(name, value) as IndexArrayType<V> | null;
+    return this.indexes.getInverseEntry(
+      name,
+      value,
+    ) as IndexArrayType<V> | null;
   }
 
   getItemsByConfig(condition: (item: number) => boolean) {
@@ -335,7 +338,7 @@ export class VirtualFragmentsModel {
     return this._coordinatesHelper.getCoordinates(this);
   }
 
-  getPositions(localIds: number[]) {
+  getPositions(localIds?: number[]) {
     return this._coordinatesHelper.getPositions(this, localIds);
   }
 
@@ -465,16 +468,16 @@ export class VirtualFragmentsModel {
     return this._raycastHelper.rectangleRaycast(this, frustum, fullyIncluded);
   }
 
-  async getSection(plane: THREE.Plane, localIds?: number[]) {
+  getSection(plane: THREE.Plane, localIds?: number[]) {
     const indices = this.properties.getItemIdsFromLocalIds(localIds);
     return this._sectionHelper.getSection(this, plane, indices);
   }
 
-  async getAlignments() {
+  getAlignments() {
     return this._alignments.getAlignments();
   }
 
-  async getGrids() {
+  getGrids() {
     return this._grids.getGrids();
   }
 

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-helpers/coordinates-helper.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-helpers/coordinates-helper.ts
@@ -1,4 +1,3 @@
-import type { Matrix3Tuple } from "three";
 import type { VirtualFragmentsModel } from "../virtual-fragments-model";
 
 export class CoordinatesHelper {
@@ -19,7 +18,7 @@ export class CoordinatesHelper {
     return positions;
   }
 
-  getCoordinates(model: VirtualFragmentsModel): Matrix3Tuple {
+  getCoordinates(model: VirtualFragmentsModel): number[] {
     const meshes = model.data.meshes()!;
     const coords = meshes.coordinates()!;
     const position = coords.position()!;

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-helpers/coordinates-helper.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-helpers/coordinates-helper.ts
@@ -1,7 +1,8 @@
-import { VirtualFragmentsModel } from "../virtual-fragments-model";
+import type { Matrix3Tuple } from "three";
+import type { VirtualFragmentsModel } from "../virtual-fragments-model";
 
 export class CoordinatesHelper {
-  getPositions(model: VirtualFragmentsModel, localIds: number[]) {
+  getPositions(model: VirtualFragmentsModel, localIds?: number[]) {
     const positions: { x: number; y: number; z: number }[] = [];
     const itemIds = model.properties.getItemIdsFromLocalIds(localIds);
     for (const id of itemIds) {
@@ -18,7 +19,7 @@ export class CoordinatesHelper {
     return positions;
   }
 
-  getCoordinates(model: VirtualFragmentsModel): number[] {
+  getCoordinates(model: VirtualFragmentsModel): Matrix3Tuple {
     const meshes = model.data.meshes()!;
     const coords = meshes.coordinates()!;
     const position = coords.position()!;

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-helpers/section-helper.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-helpers/section-helper.ts
@@ -1,12 +1,12 @@
 import * as THREE from "three";
-import { VirtualFragmentsModel } from "../virtual-fragments-model";
 import { CurrentLod, ModelSection } from "../../model/model-types";
 import { MiscHelper, SectionGenerator } from "../../utils";
+import { VirtualFragmentsModel } from "../virtual-fragments-model";
 
 export class SectionHelper {
   private _sectionGenerator = new SectionGenerator();
 
-  async getSection(
+  getSection(
     model: VirtualFragmentsModel,
     plane: THREE.Plane,
     indices: number[],

--- a/packages/fragments/src/Utils/edit/request-filterer.ts
+++ b/packages/fragments/src/Utils/edit/request-filterer.ts
@@ -47,21 +47,18 @@ export function applyChangesToIds(
   ids: number[] | Uint32Array | Set<number>,
   key: EditKey,
   addCreatedElements: boolean,
-) {
+): number[] {
   const resultSet = new Set(ids);
   const deleteType = EditRequestType[`DELETE_${key}`];
   const createType = EditRequestType[`CREATE_${key}`];
-  if (actions) {
-    for (const action of actions) {
-      if (action.type === deleteType) {
-        resultSet.delete(action.localId as number);
-        continue;
-      }
-      if (addCreatedElements && action.type === createType) {
-        resultSet.add(action.localId as number);
-      }
+  for (const action of actions) {
+    if (action.type === deleteType) {
+      resultSet.delete(action.localId as number);
+      continue;
     }
-    return Array.from(resultSet);
+    if (addCreatedElements && action.type === createType) {
+      resultSet.add(action.localId as number);
+    }
   }
-  return ids;
+  return Array.from(resultSet);
 }


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

closes #216 

- drop redundant `async` directives
- ~~BREAKING: rename `SingleThreadedFragmentsModel#getItemsWithGeometry` to `getItemsIdsWithGeometry` for compat with `FragmentsModel`~~ exposed `getItemsIdsWithGeometry` and deprecated `getItemsWithGeometry`
- exposed `getItemsVolume`

### Additional context

#### Misalignments — methods present in one class but absent (or internal) in the other
 *
 * **In `FragmentsModel` only (missing from `SingleThreadedFragmentsModel`):**
 * - `getGuids()` — VirtualFragmentsModel exposes this but SingleThreaded does not.
 * - `getItemsWithGeometryCategories()` — same situation.
 * - `getItemsIdsWithGeometry()` — FragmentsModel only.
 * - `getCoordinationMatrix()` — FragmentsModel only.
 * - `getMergedBox()` / `getBoxes()` — FragmentsModel only.
 * - `getAlignments()` / `getHorizontalAlignments()` / `getVerticalAlignments()` / `getAlignmentStyles()` — FragmentsModel only.
 * - `getGrids()` / `getGridMaterial()` / `setGridMaterial()` / `getGridLabelMaterial()` / `setGridLabelMaterial()` — FragmentsModel only.
 * - `useCamera()` / `setLodMode()` — FragmentsModel only.
 * - `raycast()` / `raycastAll()` / `raycastWithSnapping()` / `rectangleRaycast()` — FragmentsModel only.
 * - `setVisible()` / `toggleVisible()` / `resetVisible()` / `getVisible()` / `getItemsByVisibility()` — FragmentsModel only.
 * - `highlight()` / `setColor()` / `resetColor()` / `setOpacity()` / `resetOpacity()` — FragmentsModel only.
 * - `getHighlight()` / `resetHighlight()` / `getHighlightItemIds()` — FragmentsModel only.
 * - `getItemsMaterialDefinition()` — FragmentsModel only.
 * - `getAttributesUniqueValues()` — FragmentsModel only.
 * - `getEditedElements()` — FragmentsModel only.
 * - `getItemsVolume()` — FragmentsModel only.
 * - `getAttributeNames()` / `getAttributeValues()` / `getAttributeTypes()` / `getRelationNames()` — FragmentsModel only.
 * - `getGeometries()` — FragmentsModel only.
 * - `getItem()` — FragmentsModel only.
 *
 * **In `SingleThreadedFragmentsModel` only (absent or internal in `FragmentsModel`):**
 * - `edit()` — public in SingleThreaded; `FragmentsModel` exposes `_edit()` (internal) and routes edits through the `Editor` class.
 * - `reset()` / `save()` — same; `_reset()` / `_save()` are internal in FragmentsModel.
 * - `undo()` / `redo()` — SingleThreaded only; no equivalent in FragmentsModel.
 * - `getRequests()` / `setRequests()` / `selectRequest()` — SingleThreaded only; `_getRequests()` etc. are internal in FragmentsModel.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
