### PR TITLE
cleanup(): rm dev console.log

### DIFF
--- a/packages/fragments/src/Utils/edit/edit-function.ts
+++ b/packages/fragments/src/Utils/edit/edit-function.ts
@@ -1409,7 +1409,6 @@ export function edit(
 
     // Guid
     if (attributes.guid) {
-      console.log(attributes.guid);
       guidsOffsets.push(builder.createSharedString(attributes.guid));
       guidsItems.push(currentId);
     }


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Remove a dev console.log
Isn't there a linter that cathes these things before building?
