### PR TITLE
perf(FragmentsModels): memoize localId index lookups in properties controller

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-properties-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-properties-controller.ts
@@ -110,6 +110,49 @@ export class VirtualPropertiesController {
 
   private _relations = new Map<number, Record<string, number[]>>();
 
+  // Memoized localId → array index lookups. The flatbuffer accessors return
+  // a fresh TypedArray view on every call, so the caches are keyed by the
+  // underlying buffer and length instead of array identity. Without these,
+  // every getItemAttributes/getItemRelations call does a linear indexOf scan,
+  // which makes bulk reads (e.g. getItemsData over all psets) O(n²).
+  private _localIdIndexCache: {
+    buffer: ArrayBufferLike;
+    length: number;
+    map: Map<number, number>;
+  } | null = null;
+
+  private _relationsItemIndexCache: {
+    buffer: ArrayBufferLike;
+    length: number;
+    map: Map<number, number>;
+  } | null = null;
+
+  private indexOfLocalId(localId: number): number | undefined {
+    const arr = this._model.localIdsArray();
+    if (!arr) return undefined;
+    let cache = this._localIdIndexCache;
+    if (!cache || cache.length !== arr.length || cache.buffer !== arr.buffer) {
+      const map = new Map<number, number>();
+      for (let i = 0; i < arr.length; i++) map.set(arr[i], i);
+      cache = { buffer: arr.buffer, length: arr.length, map };
+      this._localIdIndexCache = cache;
+    }
+    return cache.map.get(localId) ?? -1;
+  }
+
+  private indexOfRelationsItem(localId: number): number | undefined {
+    const arr = this._model.relationsItemsArray();
+    if (!arr) return undefined;
+    let cache = this._relationsItemIndexCache;
+    if (!cache || cache.length !== arr.length || cache.buffer !== arr.buffer) {
+      const map = new Map<number, number>();
+      for (let i = 0; i < arr.length; i++) map.set(arr[i], i);
+      cache = { buffer: arr.buffer, length: arr.length, map };
+      this._relationsItemIndexCache = cache;
+    }
+    return cache.map.get(localId) ?? -1;
+  }
+
   private getAllLocalIds() {
     return this._model.localIdsArray() ?? [];
   }
@@ -508,7 +551,7 @@ export class VirtualPropertiesController {
     if (localId === null) {
       return null;
     }
-    const index = this._model.localIdsArray()?.indexOf(localId);
+    const index = this.indexOfLocalId(localId);
     if (index === undefined || index === -1) {
       // If the item was created, return the created data
       const data: Record<string, { value: any; type?: string }> = {};
@@ -742,7 +785,7 @@ export class VirtualPropertiesController {
       return null;
     }
     const relations = this._relations.get(localId) ?? {};
-    const index = this._model.relationsItemsArray()?.indexOf(localId);
+    const index = this.indexOfRelationsItem(localId);
     if (index === undefined || index === -1) {
       return Object.keys(relations).length > 0 ? relations : null;
     }


### PR DESCRIPTION
## Problem

`getItemAttributes` and `getItemRelations` in `VirtualPropertiesController` resolve the flatbuffer array index with a linear `indexOf` scan on every call:

```ts
const index = this._model.localIdsArray()?.indexOf(localId);
```

Any bulk read (e.g. `getItemsData` over all property sets, property panels, relation traversals) becomes O(n²). On a real-world 43 MB model with 121k `IFCPROPERTYSET` items, reading pset names + property values via `getItemsData` took **18+ minutes** of CPU.

## Fix

Memoize a `localId → index` `Map` for both `localIdsArray` and `relationsItemsArray`. The flatbuffer accessors return a fresh TypedArray view on every call, so the memo is keyed by the underlying `buffer` identity + length instead of array identity, and rebuilds automatically if the model buffer changes (e.g. after edits regenerate the buffer). Items created via edit requests are absent from the map, so lookups fall through to the existing `index === -1` code path unchanged.

## Results (real IFC-derived fragments models)

| Operation | Before | After |
|---|---|---|
| getItemsData over 34k psets + 394k properties (17 MB model) | 41 s | 2.2 s |
| getItemsData over 121k psets (43 MB model) | 18+ min | ~13 s |

Query results verified identical before/after on real project filters (element sets compared pairwise).

No API changes; single file touched.
