### PR TITLE
perf(FragmentsModels): use Set lookup for itemIds filter in getItemsByAttribute

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-properties-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-properties-controller.ts
@@ -919,11 +919,17 @@ export class VirtualPropertiesController {
 
     const missingItemsToIterate = new Set<number>(itemIds);
 
+    // Set lookup instead of Array.includes: with a candidate list of size m
+    // (e.g. from a category pre-filter) the includes call made this loop
+    // O(n × m) — on a model with 121k property sets a single
+    // getItemsByQuery pset query took ~5 minutes; with the Set it takes ~1s
+    const itemIdSet = itemIds?.length ? new Set<number>(itemIds) : null;
+
     for (let i = 0; i < allAttributesLength; i++) {
       const localId = this._model.localIds(i);
       if (localId === null) continue;
       missingItemsToIterate.delete(localId);
-      if (itemIds?.length && !itemIds.includes(localId)) continue;
+      if (itemIdSet && !itemIdSet.has(localId)) continue;
       const attribute = this._model.attributes(i);
       if (!attribute) continue;
 


### PR DESCRIPTION
## Problem

`getItemsByAttribute` checks candidate membership with `Array.includes` inside its loop over all items:

```ts
if (itemIds?.length && !itemIds.includes(localId)) continue;
```

Any `getItemsByQuery` that passes a candidate list (e.g. a `categories` pre-filter resolving to many items) becomes O(n × m). On a real-world 43 MB model, a pset query (`categories: [/^IFCPROPERTYSET$/i]` + attribute + relation) has 121k candidates, and a single query takes **~5 minutes**.

## Fix

Build a `Set` from `itemIds` once before the loop and use `Set.has` for the membership check. The function already builds `new Set(itemIds)` for missing-item tracking, so this reuses the same idea.

## Results (real IFC-derived fragments model, 43 MB, 121k property sets)

| | Before | After |
|---|---|---|
| Single pset `getItemsByQuery` | ~315 s | **~1.1 s** |

Query results verified identical before/after (element sets compared pairwise on real project filters).

Complements #245 (memoized localId index lookups) — the two together take bulk property queries on this model from tens of minutes to ~1 s.
