### PR TITLE
feat(): ifc parser stream

### DIFF
--- a/packages/fragments/src/Utils/ifc-parsing-utils.ts
+++ b/packages/fragments/src/Utils/ifc-parsing-utils.ts
@@ -98,3 +98,137 @@ export function extractArgsString(raw: string | undefined): string | null {
   if (lastParen < 0) return null;
   return raw.substring(idx + 1, lastParen);
 }
+
+/** STEP tape type codes (mirrors web-ifc internals) */
+enum StepTapeType {
+  String = 1, // 'foo'
+  Label = 2, // IFCLABEL('foo') — typed value / select
+  Enum = 3, // .SOMEVALUE.
+  Real = 4, // 3.14
+  Ref = 5, // #123
+  Empty = 6, // $
+  Int = 10,
+}
+
+type TapeItem =
+  | {
+      type: StepTapeType.String | StepTapeType.Label | StepTapeType.Enum;
+      value: string;
+      name?: string;
+    }
+  | { type: StepTapeType.Real | StepTapeType.Int; value: number }
+  | { type: StepTapeType.Ref; value: number }
+  | { type: StepTapeType.Empty; value: null }
+  | TapeItem[];
+
+/** Recursive descent through a STEP token stream. */
+function parseList(
+  src: string,
+  pos: number,
+  end: number,
+): { items: TapeItem[]; pos: number } {
+  const items: TapeItem[] = [];
+
+  while (pos < end) {
+    // skip whitespace and commas
+    while (pos < end && (src[pos] === "," || src[pos] === " ")) pos++;
+    if (pos >= end) break;
+
+    const ch = src[pos];
+
+    if (ch === "$") {
+      // omitted / null attribute
+      items.push({ type: StepTapeType.Empty, value: null });
+      pos++;
+    } else if (ch === "*") {
+      // redeclared attribute (treat same as omitted)
+      items.push({ type: StepTapeType.Empty, value: null });
+      pos++;
+    } else if (ch === "#") {
+      // entity reference: #12345
+      pos++;
+      let numStr = "";
+      while (pos < end && src[pos] >= "0" && src[pos] <= "9")
+        numStr += src[pos++];
+      items.push({ type: StepTapeType.Ref, value: parseInt(numStr, 10) });
+    } else if (ch === ".") {
+      // enum: .SOMEVALUE.
+      pos++;
+      let name = "";
+      while (pos < end && src[pos] !== ".") name += src[pos++];
+      pos++; // consume closing "."
+      items.push({ type: StepTapeType.Enum, value: name });
+    } else if (ch === "'") {
+      // string: 'hello world'  ('' is an escaped single quote)
+      pos++;
+      let value = "";
+      while (pos < end) {
+        if (src[pos] === "'" && src[pos + 1] === "'") {
+          value += "'";
+          pos += 2;
+        } else if (src[pos] === "'") {
+          pos++;
+          break;
+        } else {
+          value += src[pos++];
+        }
+      }
+      items.push({ type: StepTapeType.String, value });
+    } else if (ch === "(") {
+      // aggregate / list: (item, item, ...)
+      const inner = parseList(src, pos + 1, end);
+      pos = inner.pos + 1; // skip closing ")"
+      items.push(inner.items as unknown as TapeItem);
+    } else if (ch === "-" || (ch >= "0" && ch <= "9")) {
+      // numeric: integer or real
+      let numStr = "";
+      if (ch === "-") {
+        numStr += "-";
+        pos++;
+      }
+      while (
+        pos < end &&
+        ((src[pos] >= "0" && src[pos] <= "9") ||
+          src[pos] === "." ||
+          src[pos] === "E" ||
+          src[pos] === "e" ||
+          src[pos] === "+" ||
+          src[pos] === "-")
+      ) {
+        numStr += src[pos++];
+      }
+      const isReal = numStr.includes(".") || numStr.toUpperCase().includes("E");
+      items.push(
+        isReal
+          ? { type: StepTapeType.Real, value: parseFloat(numStr) }
+          : { type: StepTapeType.Int, value: parseInt(numStr, 10) },
+      );
+    } else if ((ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z")) {
+      // typed value / select: IFCLABEL('foo') or IFCLENGTHMEASURE(3.14)
+      let name = "";
+      while (pos < end && src[pos] !== "(") name += src[pos++];
+      pos++; // consume "("
+      const inner = parseList(src, pos, end);
+      pos = inner.pos + 1; // skip ")"
+
+      // A typed value wraps a single primitive as a LABEL tape item
+      items.push({
+        type: StepTapeType.Label,
+        value: inner.items[0] as any,
+        name,
+      });
+    } else {
+      pos++; // skip unexpected character
+    }
+  }
+
+  return { items, pos };
+}
+
+/** Parse the argument list of a STEP data line into a web-ifc tape. */
+export function parseStepArguments(line: string): TapeItem[] {
+  // Extract the argument substring: #ID=TYPENAME(args);
+  const args = extractArgsString(line);
+  if (args === null) return [];
+  return parseList(args, 0, args.length).items;
+}

--- a/packages/fragments/src/Utils/ifc-parsing-utils.ts
+++ b/packages/fragments/src/Utils/ifc-parsing-utils.ts
@@ -1,7 +1,25 @@
 // ---------------------------------------------------------------------------
 // Parse helpers — manual charCode-based extractors for speed on 37M+ lines
 // ---------------------------------------------------------------------------
-interface LineMeta {
+// ---------------------------------------------------------------------------
+// STEP argument tokenizer — produces web-ifc's raw tape shape, so the result
+// can be fed straight into webIfc.FromRawLineData (the registry GetLine uses).
+// Token type codes come from web-ifc's exported constants; verified against
+// web-ifc's own GetRawLineData output:
+//   - `$` (omitted)      → null
+//   - `*` (derived)      → no slot at all
+//   - `'text'`           → { type: STRING, value: <decoded text> }
+//   - `.ENUM.`           → { type: ENUM, value: name }, `.T.`/`.F.`/`.U.`
+//                          become true / false / undefined
+//   - `1.5`, `"00FF"`    → { type: REAL, value: <raw literal text> }
+//   - `42`               → { type: INTEGER, value: number }
+//   - `#123`             → { type: REF, value: expressID }
+//   - `IFCLABEL('x')`    → { type: LABEL, typecode, value: <inner primitive> }
+//   - `( ... )`          → StepArgument[]
+// ---------------------------------------------------------------------------
+import * as webIfc from "web-ifc";
+
+export interface LineMeta {
   id: number;
   type: string;
 }
@@ -99,139 +117,256 @@ export function extractArgsString(raw: string | undefined): string | null {
   return raw.substring(idx + 1, lastParen);
 }
 
-/** STEP tape type codes (mirrors web-ifc internals) */
-enum StepTapeType {
-  String = 1, // 'foo'
-  Label = 2, // IFCLABEL('foo') — typed value / select
-  Enum = 3, // .SOMEVALUE.
-  Real = 4, // 3.14
-  Ref = 5, // #123
-  Empty = 6, // $
-  Int = 10,
+const { STRING, LABEL, ENUM, REAL, REF, INTEGER } = webIfc;
+
+export type StepArgument =
+  | null
+  | StepArgument[]
+  | {
+      type: number;
+      value?: string | number | boolean | StepArgument[];
+      typecode?: number;
+    };
+
+/** Decode a raw STEP string body: `''`, `\\`, `\S\c`, `\X\hh`, `\X2\…\X0\`. */
+export function decodeStepString(raw: string): string {
+  if (raw.indexOf("'") === -1 && raw.indexOf("\\") === -1) return raw;
+  let out = "";
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw.charCodeAt(i);
+    if (c === 39) {
+      // '' — escaped quote
+      out += "'";
+      i++;
+    } else if (c === 92) {
+      // "\"
+      const next = raw[i + 1];
+      if (next === "\\") {
+        out += "\\";
+        i++;
+      } else if (next === "S" && raw[i + 2] === "\\") {
+        // \S\c — ISO 8859 upper half
+        out += String.fromCharCode(raw.charCodeAt(i + 3) + 0x80);
+        i += 3;
+      } else if (next === "P" && raw[i + 3] === "\\") {
+        // \PA\ — codepage directive; consumed, \S\ decodes as ISO 8859-1
+        i += 3;
+      } else if (next === "X" && raw[i + 2] === "\\") {
+        // \X\hh — single ISO 8859-1 byte
+        out += String.fromCharCode(parseInt(raw.substr(i + 3, 2), 16));
+        i += 4;
+      } else if (next === "X" && (raw[i + 2] === "2" || raw[i + 2] === "4")) {
+        // \X2\hhhh…\X0\ (UTF-16 units) or \X4\hhhhhhhh…\X0\ (code points)
+        const width = raw[i + 2] === "2" ? 4 : 8;
+        const close = raw.indexOf("\\X0\\", i + 4);
+        const hex = raw.substring(i + 4, close === -1 ? raw.length : close);
+        for (let k = 0; k + width <= hex.length; k += width) {
+          const code = parseInt(hex.substr(k, width), 16);
+          out +=
+            width === 4
+              ? String.fromCharCode(code)
+              : String.fromCodePoint(code);
+        }
+        i = close === -1 ? raw.length : close + 3;
+      } else {
+        out += raw[i];
+      }
+    } else {
+      out += raw[i];
+    }
+  }
+  return out;
 }
 
-type TapeItem =
-  | {
-      type: StepTapeType.String | StepTapeType.Label | StepTapeType.Enum;
-      value: string;
-      name?: string;
-    }
-  | { type: StepTapeType.Real | StepTapeType.Int; value: number }
-  | { type: StepTapeType.Ref; value: number }
-  | { type: StepTapeType.Empty; value: null }
-  | TapeItem[];
+function parseError(src: string, pos: number, reason: string): Error {
+  return new Error(
+    `Invalid Ifc argument at position ${pos} (${reason}): ${src.slice(Math.max(0, pos - 20), pos + 20)}`,
+  );
+}
 
 /** Recursive descent through a STEP token stream. */
 function parseList(
   src: string,
   pos: number,
   end: number,
-): { items: TapeItem[]; pos: number } {
-  const items: TapeItem[] = [];
+): { items: StepArgument[]; pos: number } {
+  const items: StepArgument[] = [];
 
   while (pos < end) {
-    // skip whitespace and commas
-    while (pos < end && (src[pos] === "," || src[pos] === " ")) pos++;
+    // skip whitespace, commas, and /* */ comments between tokens
+    while (pos < end) {
+      const c = src.charCodeAt(pos);
+      if (c === 44 || c <= 32) {
+        // "," or whitespace
+        pos++;
+      } else if (c === 47 && src.charCodeAt(pos + 1) === 42) {
+        // "/*"
+        const close = src.indexOf("*/", pos + 2);
+        if (close === -1 || close >= end) {
+          throw parseError(src, pos, "unterminated comment");
+        }
+        pos = close + 2;
+      } else break;
+    }
     if (pos >= end) break;
 
-    const ch = src[pos];
+    const c = src.charCodeAt(pos);
 
     // end of the enclosing list — the caller consumes the ")"
-    if (ch === ")") break;
+    if (c === 41) break;
 
-    if (ch === "$") {
-      // omitted / null attribute
-      items.push({ type: StepTapeType.Empty, value: null });
+    if (c === 36) {
+      // "$" — omitted attribute: null, like web-ifc's tape
+      items.push(null);
       pos++;
-    } else if (ch === "*") {
-      // redeclared attribute (treat same as omitted)
-      items.push({ type: StepTapeType.Empty, value: null });
+    } else if (c === 42) {
+      // "*" — derived attribute: web-ifc emits no slot for it
       pos++;
-    } else if (ch === "#") {
-      // entity reference: #12345
+    } else if (c === 35) {
+      // "#" — entity reference
       pos++;
-      let numStr = "";
-      while (pos < end && src[pos] >= "0" && src[pos] <= "9")
-        numStr += src[pos++];
-      items.push({ type: StepTapeType.Ref, value: parseInt(numStr, 10) });
-    } else if (ch === ".") {
-      // enum: .SOMEVALUE.
-      pos++;
-      let name = "";
-      while (pos < end && src[pos] !== ".") name += src[pos++];
-      pos++; // consume closing "."
-      items.push({ type: StepTapeType.Enum, value: name });
-    } else if (ch === "'") {
-      // string: 'hello world'  ('' is an escaped single quote)
-      pos++;
-      let value = "";
+      const digitsStart = pos;
+      let id = 0;
       while (pos < end) {
-        if (src[pos] === "'" && src[pos + 1] === "'") {
-          value += "'";
-          pos += 2;
-        } else if (src[pos] === "'") {
+        const d = src.charCodeAt(pos);
+        if (d >= 48 && d <= 57) {
+          id = id * 10 + (d - 48);
           pos++;
-          break;
-        } else {
-          value += src[pos++];
-        }
+        } else break;
       }
-      items.push({ type: StepTapeType.String, value });
-    } else if (ch === "(") {
-      // aggregate / list: (item, item, ...)
+      if (pos === digitsStart)
+        throw parseError(src, pos, "expected digits after '#'");
+      items.push({ type: REF, value: id });
+    } else if (c === 46) {
+      // "." — enum: .SOMEVALUE.
+      pos++;
+      const nameStart = pos;
+      while (pos < end && src.charCodeAt(pos) !== 46) pos++;
+      if (pos >= end) throw parseError(src, nameStart, "unterminated enum");
+      const name = src.substring(nameStart, pos);
+      pos++; // consume closing "."
+      if (name === "T") items.push({ type: ENUM, value: true });
+      else if (name === "F") items.push({ type: ENUM, value: false });
+      else if (name === "U") items.push({ type: ENUM, value: undefined });
+      else items.push({ type: ENUM, value: name });
+    } else if (c === 39) {
+      // "'" — string; find the closing quote, treating '' as an escape
+      pos++;
+      let i = pos;
+      while (i < end) {
+        if (src.charCodeAt(i) === 39) {
+          if (src.charCodeAt(i + 1) === 39 && i + 1 < end) i += 2;
+          else break;
+        } else i++;
+      }
+      if (i >= end) throw parseError(src, pos, "unterminated string");
+      items.push({
+        type: STRING,
+        value: decodeStepString(src.substring(pos, i)),
+      });
+      pos = i + 1;
+    } else if (c === 34) {
+      // '"' — binary literal; web-ifc tapes it as REAL with the raw hex text
+      pos++;
+      const hexStart = pos;
+      while (pos < end && src.charCodeAt(pos) !== 34) pos++;
+      if (pos >= end)
+        throw parseError(src, hexStart, "unterminated binary literal");
+      items.push({ type: REAL, value: src.substring(hexStart, pos) });
+      pos++;
+    } else if (c === 40) {
+      // "(" — aggregate / list
       const inner = parseList(src, pos + 1, end);
-      pos = inner.pos + 1; // skip closing ")"
-      items.push(inner.items as unknown as TapeItem);
-    } else if (ch === "-" || (ch >= "0" && ch <= "9")) {
-      // numeric: integer or real
-      let numStr = "";
-      if (ch === "-") {
-        numStr += "-";
-        pos++;
+      if (inner.pos >= end || src.charCodeAt(inner.pos) !== 41) {
+        throw parseError(src, pos, "unterminated aggregate");
       }
-      while (
-        pos < end &&
-        ((src[pos] >= "0" && src[pos] <= "9") ||
-          src[pos] === "." ||
-          src[pos] === "E" ||
-          src[pos] === "e" ||
-          src[pos] === "+" ||
-          src[pos] === "-")
-      ) {
-        numStr += src[pos++];
+      pos = inner.pos + 1;
+      items.push(inner.items);
+    } else if (c === 45 || c === 43 || (c >= 48 && c <= 57)) {
+      // numeric: integer, or real kept as its raw literal text (web-ifc parity)
+      const numStart = pos;
+      if (c === 45 || c === 43) pos++;
+      let hasDigits = false;
+      let isReal = false;
+      while (pos < end) {
+        const d = src.charCodeAt(pos);
+        if (d >= 48 && d <= 57) {
+          hasDigits = true;
+          pos++;
+        } else if (d === 46) {
+          // "."
+          isReal = true;
+          pos++;
+        } else if (d === 69 || d === 101) {
+          // "E" / "e" with optional sign
+          isReal = true;
+          pos++;
+          const s = src.charCodeAt(pos);
+          if (s === 43 || s === 45) pos++;
+        } else break;
       }
-      const isReal = numStr.includes(".") || numStr.toUpperCase().includes("E");
+      if (!hasDigits) throw parseError(src, numStart, "malformed number");
       items.push(
         isReal
-          ? { type: StepTapeType.Real, value: parseFloat(numStr) }
-          : { type: StepTapeType.Int, value: parseInt(numStr, 10) },
+          ? { type: REAL, value: src.substring(numStart, pos) }
+          : {
+              type: INTEGER,
+              value: parseInt(src.substring(numStart, pos), 10),
+            },
       );
-    } else if ((ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z")) {
+    } else if ((c >= 65 && c <= 90) || (c >= 97 && c <= 122)) {
       // typed value / select: IFCLABEL('foo') or IFCLENGTHMEASURE(3.14)
-      let name = "";
-      while (pos < end && src[pos] !== "(") name += src[pos++];
-      pos++; // consume "("
-      const inner = parseList(src, pos, end);
-      pos = inner.pos + 1; // skip ")"
+      const nameStart = pos;
+      while (pos < end) {
+        const d = src.charCodeAt(pos);
+        if (
+          (d >= 65 && d <= 90) ||
+          (d >= 97 && d <= 122) ||
+          (d >= 48 && d <= 57) ||
+          d === 95
+        )
+          pos++;
+        else break;
+      }
+      const name = src.substring(nameStart, pos);
+      while (pos < end && src.charCodeAt(pos) <= 32) pos++;
+      if (pos >= end || src.charCodeAt(pos) !== 40) {
+        throw parseError(src, nameStart, `expected '(' after '${name}'`);
+      }
+      const inner = parseList(src, pos + 1, end);
+      if (inner.pos >= end || src.charCodeAt(inner.pos) !== 41) {
+        throw parseError(src, pos, "unterminated typed value");
+      }
+      pos = inner.pos + 1;
 
-      // A typed value wraps a single primitive as a LABEL tape item
+      // web-ifc flattens a typed value to its numeric typecode + inner primitive
+      const typecode = (webIfc as Record<string, unknown>)[name.toUpperCase()];
+      const first = inner.items[0];
       items.push({
-        type: StepTapeType.Label,
-        value: inner.items[0] as any,
-        name,
+        type: LABEL,
+        typecode: typeof typecode === "number" ? typecode : undefined,
+        value:
+          first === null || Array.isArray(first)
+            ? first ?? undefined
+            : first.value,
       });
     } else {
-      pos++; // skip unexpected character
+      throw parseError(src, pos, `unexpected character '${src[pos]}'`);
     }
   }
 
   return { items, pos };
 }
 
-/** Parse the argument list of a STEP data line into a web-ifc tape. */
-export function parseStepArguments(line: string): TapeItem[] {
-  // Extract the argument substring: #ID=TYPENAME(args);
-  const args = extractArgsString(line);
-  if (args === null) return [];
-  return parseList(args, 0, args.length).items;
+/**
+ * Parse the argument list of a STEP data statement (`#ID=TYPENAME(args);`)
+ * into web-ifc's raw tape shape, suitable for `webIfc.FromRawLineData`.
+ * Throws on malformed arguments.
+ */
+export function parseStepArguments(line: string): StepArgument[] {
+  const start = line.indexOf("(");
+  if (start < 0) return [];
+  const end = line.lastIndexOf(")");
+  if (end < start) return [];
+  return parseList(line, start + 1, end).items;
 }

--- a/packages/fragments/src/Utils/ifc-parsing-utils.ts
+++ b/packages/fragments/src/Utils/ifc-parsing-utils.ts
@@ -136,6 +136,9 @@ function parseList(
 
     const ch = src[pos];
 
+    // end of the enclosing list — the caller consumes the ")"
+    if (ch === ")") break;
+
     if (ch === "$") {
       // omitted / null attribute
       items.push({ type: StepTapeType.Empty, value: null });

--- a/packages/fragments/src/Utils/ifc-stream.test.ts
+++ b/packages/fragments/src/Utils/ifc-stream.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "vitest";
-import { streamAsyncIterator } from "./ifc-stream";
+import * as webIfc from "web-ifc";
+import { parseStepArguments } from "./ifc-parsing-utils";
+import {
+  IfcDecoderStream,
+  IfcParserStream,
+  streamAsyncIterator,
+} from "./ifc-stream";
 
 const sourceOf = (values: number[], onCancel: () => void) =>
   new ReadableStream<number>({
@@ -55,4 +61,171 @@ test("streamAsyncIterator does not cancel a fully drained source", async () => {
   expect(seen).toEqual([1, 2, 3]);
   expect(cancelled).toBe(false);
   expect(stream.locked).toBe(false);
+});
+
+// ---------------------------------------------------------------------------
+// parseStepArguments
+// ---------------------------------------------------------------------------
+
+// tape item shorthands (codes mirror web-ifc internals)
+const str = (value: string) => ({ type: 1, value });
+const label = (name: string, value: unknown) => ({ type: 2, value, name });
+const enumOf = (value: string) => ({ type: 3, value });
+const real = (value: number) => ({ type: 4, value });
+const ref = (value: number) => ({ type: 5, value });
+const empty = () => ({ type: 6, value: null });
+const int = (value: number) => ({ type: 10, value });
+
+test("parseStepArguments tokenizes every STEP primitive", () => {
+  const line =
+    "#1=IFCFOO('it''s',$,*,#42,.ENUMVAL.,3.5,-2,1.0E-3,IFCLABEL('x'),(1,(2)));";
+  expect(parseStepArguments(line)).toEqual([
+    str("it's"),
+    empty(),
+    empty(),
+    ref(42),
+    enumOf("ENUMVAL"),
+    real(3.5),
+    int(-2),
+    real(0.001),
+    label("IFCLABEL", str("x")),
+    [int(1), [int(2)]],
+  ]);
+});
+
+test("parseStepArguments keeps arguments after a nested aggregate", () => {
+  expect(parseStepArguments("#1=IFCFOO((1,2),'after',());")).toEqual([
+    [int(1), int(2)],
+    str("after"),
+    [],
+  ]);
+});
+
+test("parseStepArguments keeps arguments after a typed value", () => {
+  expect(parseStepArguments("#1=IFCFOO(IFCLABEL('x'),$);")).toEqual([
+    label("IFCLABEL", str("x")),
+    empty(),
+  ]);
+});
+
+test("parseStepArguments returns no arguments for a line without parens", () => {
+  expect(parseStepArguments("ENDSEC;")).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// IfcParserStream
+// ---------------------------------------------------------------------------
+
+const linesOf = (lines: string[]) =>
+  new ReadableStream<string>({
+    start(controller) {
+      for (const line of lines) controller.enqueue(line);
+      controller.close();
+    },
+  });
+
+const collect = async <T>(stream: ReadableStream<T>) => {
+  const out: T[] = [];
+  for await (const value of streamAsyncIterator(stream)) out.push(value);
+  return out;
+};
+
+const HEADER = [
+  "ISO-10303-21;",
+  "HEADER;",
+  "FILE_DESCRIPTION((''),'2;1');",
+  "FILE_NAME('','',(''),(''),'','','');",
+  "FILE_SCHEMA(('IFC4'));",
+  "ENDSEC;",
+  "DATA;",
+];
+
+const FOOTER = ["ENDSEC;", "END-ISO-10303-21;"];
+
+test("IfcParserStream parses data lines into web-ifc entities", async () => {
+  const stream = linesOf([
+    ...HEADER,
+    "#1=IFCCARTESIANPOINT((1.5,2.5,3.5));",
+    "#2=IFCPROPERTYSINGLEVALUE('Answer',$,IFCLABEL('forty two'),$);",
+    ...FOOTER,
+  ]).pipeThrough(new IfcParserStream());
+
+  const entities = await collect(stream);
+  expect(entities).toHaveLength(2);
+
+  const [point, prop] = entities as any[];
+  expect(point.expressID).toBe(1);
+  expect(point.type).toBe(webIfc.IFCCARTESIANPOINT);
+  expect(point.Coordinates).toEqual([real(1.5), real(2.5), real(3.5)]);
+
+  expect(prop.expressID).toBe(2);
+  expect(prop.type).toBe(webIfc.IFCPROPERTYSINGLEVALUE);
+  expect(prop.Name).toEqual(str("Answer"));
+  expect(prop.Description).toEqual(empty());
+  expect(prop.NominalValue).toEqual(label("IFCLABEL", str("forty two")));
+  expect(prop.Unit).toEqual(empty());
+});
+
+test("IfcParserStream errors when the header has no FILE_SCHEMA", async () => {
+  const stream = linesOf(["ISO-10303-21;", "HEADER;", "DATA;"]).pipeThrough(
+    new IfcParserStream(),
+  );
+
+  await expect(collect(stream)).rejects.toBe("Ifc schema not found");
+});
+
+test("IfcParserStream errors on an unsupported schema", async () => {
+  const stream = linesOf([
+    "HEADER;",
+    "FILE_SCHEMA(('IFC9000'));",
+    "DATA;",
+  ]).pipeThrough(new IfcParserStream());
+
+  await expect(collect(stream)).rejects.toBe("Ifc schema 'IFC9000' not found");
+});
+
+test("IfcParserStream errors on a corrupted data line", async () => {
+  const stream = linesOf([...HEADER, "garbage"]).pipeThrough(
+    new IfcParserStream(),
+  );
+
+  await expect(collect(stream)).rejects.toBe("Ifc corrupted line: garbage");
+});
+
+test("IfcParserStream errors on an unknown entity type", async () => {
+  const stream = linesOf([...HEADER, "#1=IFCNOTAREALTYPE($);"]).pipeThrough(
+    new IfcParserStream(),
+  );
+
+  await expect(collect(stream)).rejects.toBe(
+    "Unknown Ifc type 'IFCNOTAREALTYPE'",
+  );
+});
+
+test("IfcDecoderStream and IfcParserStream compose over byte chunks", async () => {
+  const text = [
+    ...HEADER,
+    "#1=IFCCARTESIANPOINT((1.5,2.5,3.5));",
+    ...FOOTER,
+  ].join("\r\n");
+  const bytes = new TextEncoder().encode(text);
+  const chunked = new ReadableStream<Uint8Array>({
+    start(controller) {
+      // deliberately split mid-line to exercise the decoder's tail handling
+      for (let i = 0; i < bytes.length; i += 7) {
+        controller.enqueue(bytes.subarray(i, i + 7));
+      }
+      controller.close();
+    },
+  });
+
+  const entities = await collect(
+    chunked
+      .pipeThrough(new IfcDecoderStream())
+      .pipeThrough(new IfcParserStream()),
+  );
+
+  expect(entities).toHaveLength(1);
+  expect(entities[0].expressID).toBe(1);
+  expect(entities[0].type).toBe(webIfc.IFCCARTESIANPOINT);
 });

--- a/packages/fragments/src/Utils/ifc-stream.test.ts
+++ b/packages/fragments/src/Utils/ifc-stream.test.ts
@@ -64,33 +64,73 @@ test("streamAsyncIterator does not cancel a fully drained source", async () => {
 });
 
 // ---------------------------------------------------------------------------
-// parseStepArguments
+// IfcDecoderStream
 // ---------------------------------------------------------------------------
 
-// tape item shorthands (codes mirror web-ifc internals)
-const str = (value: string) => ({ type: 1, value });
-const label = (name: string, value: unknown) => ({ type: 2, value, name });
-const enumOf = (value: string) => ({ type: 3, value });
-const real = (value: number) => ({ type: 4, value });
-const ref = (value: number) => ({ type: 5, value });
-const empty = () => ({ type: 6, value: null });
-const int = (value: number) => ({ type: 10, value });
+const decode = async (chunks: string[]) => {
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+  const lines: string[] = [];
+  for await (const line of streamAsyncIterator(
+    source.pipeThrough(new IfcDecoderStream()),
+  )) {
+    lines.push(line);
+  }
+  return lines;
+};
+
+test("IfcDecoderStream strips a CRLF pair split across two chunks", async () => {
+  expect(await decode(["A;\r", "\nB;\r\n"])).toEqual(["A;", "B;"]);
+});
+
+// ---------------------------------------------------------------------------
+// parseStepArguments — emits web-ifc's raw tape shape
+// ---------------------------------------------------------------------------
+
+// tape item shorthands in web-ifc's raw shape
+const str = (value: string) => ({ type: webIfc.STRING, value });
+const enumOf = (value: string | boolean | undefined) => ({
+  type: webIfc.ENUM,
+  value,
+});
+// web-ifc keeps the raw literal text of reals (and binary literals) as strings
+const real = (value: string) => ({ type: webIfc.REAL, value });
+const int = (value: number) => ({ type: webIfc.INTEGER, value });
+const ref = (value: number) => ({ type: webIfc.REF, value });
+const label = (typecode: number, value: unknown) => ({
+  type: webIfc.LABEL,
+  typecode,
+  value,
+});
 
 test("parseStepArguments tokenizes every STEP primitive", () => {
   const line =
-    "#1=IFCFOO('it''s',$,*,#42,.ENUMVAL.,3.5,-2,1.0E-3,IFCLABEL('x'),(1,(2)));";
+    "#1=IFCFOO('it''s',$,#42,.ENUMVAL.,.T.,.F.,3.5,-2,1.0E-3,IFCLABEL('x'),(1,(2)));";
   expect(parseStepArguments(line)).toEqual([
     str("it's"),
-    empty(),
-    empty(),
+    null,
     ref(42),
     enumOf("ENUMVAL"),
-    real(3.5),
+    enumOf(true),
+    enumOf(false),
+    real("3.5"),
     int(-2),
-    real(0.001),
-    label("IFCLABEL", str("x")),
+    real("1.0E-3"),
+    label(webIfc.IFCLABEL, "x"),
     [int(1), [int(2)]],
   ]);
+});
+
+test("parseStepArguments emits no slot for '*' derived attributes", () => {
+  // web-ifc's raw tape for IFCSIUNIT(*,...) has 3 slots, not 4
+  expect(parseStepArguments("#1=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);")).toEqual(
+    [enumOf("LENGTHUNIT"), null, enumOf("METRE")],
+  );
 });
 
 test("parseStepArguments keeps arguments after a nested aggregate", () => {
@@ -103,9 +143,46 @@ test("parseStepArguments keeps arguments after a nested aggregate", () => {
 
 test("parseStepArguments keeps arguments after a typed value", () => {
   expect(parseStepArguments("#1=IFCFOO(IFCLABEL('x'),$);")).toEqual([
-    label("IFCLABEL", str("x")),
-    empty(),
+    label(webIfc.IFCLABEL, "x"),
+    null,
   ]);
+});
+
+test("parseStepArguments flattens typed values to their inner primitive", () => {
+  expect(
+    parseStepArguments("#1=IFCFOO(IFCBOOLEAN(.T.),IFCINTEGER(42));"),
+  ).toEqual([label(webIfc.IFCBOOLEAN, true), label(webIfc.IFCINTEGER, 42)]);
+  expect(parseStepArguments("#1=IFCFOO(IFCLOGICAL(.U.));")).toEqual([
+    label(webIfc.IFCLOGICAL, undefined),
+  ]);
+});
+
+test("parseStepArguments decodes STEP string escapes", () => {
+  expect(
+    parseStepArguments("#1=IFCFOO('caf\\X2\\00E9\\X0\\ \\S\\d \\\\x');"),
+  ).toEqual([str("café ä \\x")]);
+});
+
+test("parseStepArguments reads binary literals as raw hex text", () => {
+  expect(parseStepArguments('#1=IFCFOO(("00FF"),$);')).toEqual([
+    [real("00FF")],
+    null,
+  ]);
+});
+
+test("parseStepArguments skips /* */ comments between tokens", () => {
+  expect(parseStepArguments("#1=IFCFOO('g', /* owner */ #5);")).toEqual([
+    str("g"),
+    ref(5),
+  ]);
+});
+
+test("parseStepArguments throws on malformed tokens instead of emitting NaN", () => {
+  expect(() => parseStepArguments("#1=IFCFOO(#);")).toThrow(/digits/);
+  expect(() => parseStepArguments("#1=IFCFOO(-);")).toThrow(/malformed number/);
+  expect(() => parseStepArguments("#1=IFCFOO(%);")).toThrow(
+    /unexpected character/,
+  );
 });
 
 test("parseStepArguments returns no arguments for a line without parens", () => {
@@ -124,9 +201,13 @@ const linesOf = (lines: string[]) =>
     },
   });
 
-const collect = async <T>(stream: ReadableStream<T>) => {
-  const out: T[] = [];
-  for await (const value of streamAsyncIterator(stream)) out.push(value);
+const collect = async (lines: string[]) => {
+  const out: any[] = [];
+  for await (const entity of streamAsyncIterator(
+    linesOf(lines).pipeThrough(new IfcParserStream()),
+  )) {
+    out.push(entity);
+  }
   return out;
 };
 
@@ -142,63 +223,168 @@ const HEADER = [
 
 const FOOTER = ["ENDSEC;", "END-ISO-10303-21;"];
 
-test("IfcParserStream parses data lines into web-ifc entities", async () => {
-  const stream = linesOf([
+test("IfcParserStream produces entities matching web-ifc's GetLine shape", async () => {
+  const [point, prop] = await collect([
     ...HEADER,
-    "#1=IFCCARTESIANPOINT((1.5,2.5,3.5));",
+    "#1=IFCCARTESIANPOINT((1.5,-2.5E-1,3.));",
     "#2=IFCPROPERTYSINGLEVALUE('Answer',$,IFCLABEL('forty two'),$);",
     ...FOOTER,
-  ]).pipeThrough(new IfcParserStream());
+  ]);
 
-  const entities = await collect(stream);
-  expect(entities).toHaveLength(2);
-
-  const [point, prop] = entities as any[];
   expect(point.expressID).toBe(1);
   expect(point.type).toBe(webIfc.IFCCARTESIANPOINT);
-  expect(point.Coordinates).toEqual([real(1.5), real(2.5), real(3.5)]);
+  // attributes are typed wrappers whose .value is the primitive, like GetLine
+  expect(point.Coordinates.map((c: any) => c.value)).toEqual([1.5, -0.25, 3]);
+  expect(point.Coordinates[0].name).toBe("IFCLENGTHMEASURE");
 
   expect(prop.expressID).toBe(2);
   expect(prop.type).toBe(webIfc.IFCPROPERTYSINGLEVALUE);
-  expect(prop.Name).toEqual(str("Answer"));
-  expect(prop.Description).toEqual(empty());
-  expect(prop.NominalValue).toEqual(label("IFCLABEL", str("forty two")));
-  expect(prop.Unit).toEqual(empty());
+  expect(prop.Name.value).toBe("Answer");
+  expect(prop.Description).toBeNull(); // '$' is null, not a placeholder object
+  expect(prop.NominalValue.value).toBe("forty two");
+  expect(prop.NominalValue.name).toBe("IFCLABEL");
+  expect(prop.Unit).toBeNull();
+});
+
+test("IfcParserStream does not shift attributes of '*' derived slots", async () => {
+  const [unit] = await collect([
+    ...HEADER,
+    "#1=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);",
+    ...FOOTER,
+  ]);
+
+  expect(unit.UnitType).toEqual({ type: webIfc.ENUM, value: "LENGTHUNIT" });
+  expect(unit.Prefix).toBeNull();
+  expect(unit.Name).toEqual({ type: webIfc.ENUM, value: "METRE" });
+});
+
+test("IfcParserStream parses .T./.F. as booleans", async () => {
+  const [prop] = await collect([
+    ...HEADER,
+    "#1=IFCPROPERTYSINGLEVALUE('B',$,IFCBOOLEAN(.T.),$);",
+    ...FOOTER,
+  ]);
+
+  expect(prop.NominalValue.value).toBe(true);
+});
+
+test("IfcParserStream decodes escaped strings", async () => {
+  const [prop] = await collect([
+    ...HEADER,
+    "#1=IFCPROPERTYSINGLEVALUE('X',$,IFCTEXT('caf\\X2\\00E9\\X0\\'),$);",
+    ...FOOTER,
+  ]);
+
+  expect(prop.NominalValue.value).toBe("café");
+});
+
+test("IfcParserStream handles statements spanning or sharing physical lines", async () => {
+  const entities = await collect([
+    ...HEADER,
+    "#1=IFCPROPERTYSINGLEVALUE('Answer',$,", // wrapped across two lines
+    "  IFCLABEL('forty two'),$);",
+    "#2=IFCCARTESIANPOINT((0.,0.)); #3=IFCCARTESIANPOINT((1.,1.));", // shared line
+    ...FOOTER,
+  ]);
+
+  expect(entities.map((e) => e.expressID)).toEqual([1, 2, 3]);
+  expect(entities[0].NominalValue.value).toBe("forty two");
+});
+
+test("IfcParserStream tolerates blank, indented, and comment lines", async () => {
+  const entities = await collect([
+    ...HEADER,
+    "",
+    "/* a whole-line comment */",
+    "  #1=IFCCARTESIANPOINT((1.,2.));",
+    "/* a comment",
+    "   spanning lines */ #2=IFCCARTESIANPOINT((3.,4.));",
+    ...FOOTER,
+  ]);
+
+  expect(entities.map((e) => e.expressID)).toEqual([1, 2]);
+});
+
+test("IfcParserStream accepts spec-legal FILE_SCHEMA variants", async () => {
+  const spaced = await collect([
+    "ISO-10303-21;",
+    "HEADER;",
+    "FILE_SCHEMA (('IFC4'));", // whitespace before the parens
+    "ENDSEC;",
+    "DATA;",
+    "#1=IFCCARTESIANPOINT((0.,0.));",
+    ...FOOTER,
+  ]);
+  expect(spaced).toHaveLength(1);
+
+  const multi = await collect([
+    "ISO-10303-21;",
+    "HEADER;",
+    "FILE_SCHEMA(('NOTASCHEMA','IFC4'));", // multi-identifier list
+    "ENDSEC;",
+    "DATA;",
+    "#1=IFCCARTESIANPOINT((0.,0.));",
+    ...FOOTER,
+  ]);
+  expect(multi).toHaveLength(1);
+});
+
+test("IfcParserStream skips entity types outside the declared schema", async () => {
+  const entities = await collect([
+    "ISO-10303-21;",
+    "HEADER;",
+    "FILE_SCHEMA(('IFC2X3'));",
+    "ENDSEC;",
+    "DATA;",
+    "#1=IFCALIGNMENT($,$,$,$,$,$,$);", // IFC4X3-only type
+    "#2=IFCTOTALGARBAGETYPE($);", // not a web-ifc type at all
+    "#3=IFCCARTESIANPOINT((0.,0.));",
+    ...FOOTER,
+  ]);
+
+  expect(entities.map((e) => e.expressID)).toEqual([3]);
+});
+
+test("IfcParserStream parses entities from several DATA sections", async () => {
+  const entities = await collect([
+    ...HEADER,
+    "#1=IFCCARTESIANPOINT((0.,0.));",
+    "ENDSEC;",
+    "DATA;",
+    "#2=IFCCARTESIANPOINT((9.,9.));",
+    ...FOOTER,
+  ]);
+
+  expect(entities.map((e) => e.expressID)).toEqual([1, 2]);
 });
 
 test("IfcParserStream errors when the header has no FILE_SCHEMA", async () => {
-  const stream = linesOf(["ISO-10303-21;", "HEADER;", "DATA;"]).pipeThrough(
-    new IfcParserStream(),
+  await expect(collect(["ISO-10303-21;", "HEADER;", "DATA;"])).rejects.toThrow(
+    "Ifc schema not found",
   );
-
-  await expect(collect(stream)).rejects.toBe("Ifc schema not found");
 });
 
 test("IfcParserStream errors on an unsupported schema", async () => {
-  const stream = linesOf([
-    "HEADER;",
-    "FILE_SCHEMA(('IFC9000'));",
-    "DATA;",
-  ]).pipeThrough(new IfcParserStream());
-
-  await expect(collect(stream)).rejects.toBe("Ifc schema 'IFC9000' not found");
+  await expect(
+    collect(["HEADER;", "FILE_SCHEMA(('IFC9000'));", "DATA;"]),
+  ).rejects.toThrow("Ifc schema 'IFC9000' not found");
 });
 
-test("IfcParserStream errors on a corrupted data line", async () => {
-  const stream = linesOf([...HEADER, "garbage"]).pipeThrough(
-    new IfcParserStream(),
+test("IfcParserStream errors on a corrupted data statement", async () => {
+  await expect(collect([...HEADER, "garbage;"])).rejects.toThrow(
+    "Corrupted Ifc statement: garbage",
   );
-
-  await expect(collect(stream)).rejects.toBe("Ifc corrupted line: garbage");
 });
 
-test("IfcParserStream errors on an unknown entity type", async () => {
-  const stream = linesOf([...HEADER, "#1=IFCNOTAREALTYPE($);"]).pipeThrough(
-    new IfcParserStream(),
-  );
+test("IfcParserStream errors on truncated input instead of succeeding", async () => {
+  // ends mid-DATA with a complete last statement but no ENDSEC/END-ISO marker
+  await expect(
+    collect([...HEADER, "#1=IFCCARTESIANPOINT((0.,0.));"]),
+  ).rejects.toThrow("Unexpected end of Ifc stream");
 
-  await expect(collect(stream)).rejects.toBe(
-    "Unknown Ifc type 'IFCNOTAREALTYPE'",
+  // non-IFC input never reaches DATA; and must not succeed silently
+  await expect(collect(["hello", "world"])).rejects.toThrow(
+    "Unexpected end of Ifc stream",
   );
 });
 
@@ -219,13 +405,19 @@ test("IfcDecoderStream and IfcParserStream compose over byte chunks", async () =
     },
   });
 
-  const entities = await collect(
+  const entities: any[] = [];
+  for await (const entity of streamAsyncIterator(
     chunked
       .pipeThrough(new IfcDecoderStream())
       .pipeThrough(new IfcParserStream()),
-  );
+  )) {
+    entities.push(entity);
+  }
 
   expect(entities).toHaveLength(1);
   expect(entities[0].expressID).toBe(1);
   expect(entities[0].type).toBe(webIfc.IFCCARTESIANPOINT);
+  expect(entities[0].Coordinates.map((c: any) => c.value)).toEqual([
+    1.5, 2.5, 3.5,
+  ]);
 });

--- a/packages/fragments/src/Utils/ifc-stream.ts
+++ b/packages/fragments/src/Utils/ifc-stream.ts
@@ -1,6 +1,10 @@
 // eslint-disable-next-line max-classes-per-file
 import * as webIfc from "web-ifc";
-import { extractLineMeta, parseStepArguments } from "./ifc-parsing-utils";
+import {
+  extractLineMeta,
+  parseStepArguments,
+  StepArgument,
+} from "./ifc-parsing-utils";
 
 const crCharCode = 13; // "\r";
 const nl = "\n";
@@ -39,6 +43,8 @@ export class IfcDecoderStream extends TransformStream<Uint8Array, string> {
         if (idx !== -1) {
           let end = idx;
           if (end > 0 && text.charCodeAt(end - 1) === crCharCode) end--;
+          else if (end === 0 && tail.charCodeAt(tail.length - 1) === crCharCode)
+            tail = tail.slice(0, -1); // CRLF pair split across two chunks
           controller.enqueue(
             tail
               ? tail + text.substring(start, end)
@@ -72,7 +78,21 @@ export class IfcDecoderStream extends TransformStream<Uint8Array, string> {
   }
 }
 
+type RawFactory = (args: StepArgument[]) => webIfc.IfcLineObject;
+
+// A statement buffer beyond this is not line-oriented IFC — bail out instead
+// of accumulating the whole input in memory.
+const maxStatementLength = 64 * 1024 * 1024;
+
 /**
+ * Parses the ISO 10303-21 statements of an IFC file into web-ifc entities,
+ * matching the shape `IfcAPI.GetLine` returns (attributes hold typed value
+ * wrappers, refs are `{ type: 5, value }` handles, omitted attributes are
+ * `null`). Statements may span physical lines, share a line, or be
+ * interleaved with `/* ... *\/` comments and blank lines. Entity types
+ * outside the file's declared schema are skipped, like web-ifc does.
+ * The stream errors on corrupted statements and on input that ends before
+ * `END-ISO-10303-21;`, so truncated files are not mistaken for complete ones.
  *
  * @example
  * ```ts
@@ -97,76 +117,166 @@ export class IfcParserStream extends TransformStream<
   webIfc.IfcLineObject
 > {
   constructor() {
-    let schemaFactoryMap: Record<number, (...args: unknown[]) => any> | null =
-      null;
-    let section: "header" | "data" | "footer" = "header";
-    const header: string[] = [];
-    const schemaRE = /FILE_SCHEMA\(+'?([^')]*)'?\)+;/;
+    let factories: Record<number, RawFactory> | null = null;
+    let fileSchemas: string[] | null = null;
+    let section: "header" | "data" | "between" | "end" = "header";
+    let statement = "";
+    let inString = false;
+    let inComment = false;
 
-    function getFactory(type: string): ((line: string) => any) | null {
-      if (!schemaFactoryMap) return null;
+    function processStatement(
+      raw: string,
+      controller: TransformStreamDefaultController<webIfc.IfcLineObject>,
+    ) {
+      switch (section) {
+        case "header":
+          if (raw === "DATA") {
+            if (!fileSchemas) {
+              controller.error(new Error("Ifc schema not found"));
+              return;
+            }
+            let schemaIndex = -1;
+            for (const name of fileSchemas) {
+              schemaIndex = webIfc.SchemaNames.findIndex((names) =>
+                names?.includes(name),
+              );
+              if (schemaIndex !== -1) break;
+            }
+            if (schemaIndex === -1) {
+              controller.error(
+                new Error(`Ifc schema '${fileSchemas.join("', '")}' not found`),
+              );
+              return;
+            }
+            factories = (
+              webIfc.FromRawLineData as Record<
+                number,
+                Record<number, RawFactory>
+              >
+            )[schemaIndex];
+            section = "data";
+          } else if (raw.startsWith("FILE_SCHEMA")) {
+            try {
+              const [names] = parseStepArguments(raw);
+              if (Array.isArray(names)) {
+                const schemas: string[] = [];
+                for (const item of names) {
+                  if (
+                    item &&
+                    !Array.isArray(item) &&
+                    typeof item.value === "string"
+                  ) {
+                    schemas.push(item.value);
+                  }
+                }
+                if (schemas.length) fileSchemas = schemas;
+              }
+            } catch {
+              // a malformed FILE_SCHEMA surfaces as "schema not found" at DATA
+            }
+          }
+          break;
 
-      const typeCode = (webIfc as Record<string, unknown>)[type];
-      if (typeof typeCode !== "number") return null;
+        case "data": {
+          if (raw === "ENDSEC") {
+            section = "between";
+            return;
+          }
+          const meta = extractLineMeta(raw);
+          if (!meta) {
+            controller.error(new Error(`Corrupted Ifc statement: ${raw}`));
+            return;
+          }
+          const typeCode = (webIfc as Record<string, unknown>)[meta.type];
+          // entity types outside web-ifc or the declared schema are skipped,
+          // matching web-ifc's own tolerance for such lines
+          if (typeof typeCode !== "number") return;
+          const factory = factories?.[typeCode];
+          if (!factory) return;
+          let entity: webIfc.IfcLineObject;
+          try {
+            entity = factory(parseStepArguments(raw));
+          } catch (err) {
+            controller.error(
+              new Error(`Corrupted Ifc statement: ${raw}`, { cause: err }),
+            );
+            return;
+          }
+          entity.expressID = meta.id;
+          controller.enqueue(entity);
+          break;
+        }
 
-      const ctor = schemaFactoryMap[typeCode];
-      if (!ctor) return null;
+        case "between":
+          // ISO 10303-21 permits several DATA sections per file
+          if (raw === "DATA") section = "data";
+          else if (raw === "END-ISO-10303-21") section = "end";
+          break;
 
-      return (line: string) => {
-        const args = parseStepArguments(line);
-        return ctor(args);
-      };
+        default:
+          break;
+      }
     }
 
     super({
       transform(line, controller) {
-        switch (section) {
-          case "header":
-            if (line.trim() === "DATA;") {
-              const schemaLine = header.find((line) => schemaRE.test(line));
-              const schema = schemaLine && schemaRE.exec(schemaLine)?.[1];
-              if (!schema) {
-                controller.error("Ifc schema not found");
-                return;
-              }
-              const schemaIndex = webIfc.SchemaNames.findIndex((names) =>
-                names?.includes(schema),
-              );
-              if (schemaIndex === -1) {
-                controller.error(`Ifc schema '${schema}' not found`);
-                return;
-              }
-              schemaFactoryMap = webIfc.Constructors[schemaIndex];
-              section = "data";
-              return;
-            }
-            header.push(line);
-            break;
+        const length = line.length;
+        let segStart = 0;
+        let i = 0;
+        while (i < length) {
+          const c = line.charCodeAt(i);
+          if (inComment) {
+            if (c === 42 && line.charCodeAt(i + 1) === 47) {
+              // "*/"
+              inComment = false;
+              i += 2;
+              segStart = i;
+            } else i++;
+            continue;
+          }
+          if (inString) {
+            // '' pairs toggle twice, so plain toggling tracks them correctly
+            if (c === 39) inString = false;
+            i++;
+            continue;
+          }
+          if (c === 39) {
+            // "'"
+            inString = true;
+            i++;
+            continue;
+          }
+          if (c === 47 && line.charCodeAt(i + 1) === 42) {
+            // "/*" — drop the comment, keep it as a token separator
+            statement += `${line.substring(segStart, i)} `;
+            inComment = true;
+            i += 2;
+            continue;
+          }
+          if (c === 59) {
+            // ";" — a complete statement
+            const raw = (statement + line.substring(segStart, i)).trim();
+            statement = "";
+            i++;
+            segStart = i;
+            if (raw) processStatement(raw, controller);
+            continue;
+          }
+          i++;
+        }
+        if (!inComment && segStart < length) {
+          statement += `${line.substring(segStart)}\n`;
+          if (statement.length > maxStatementLength) {
+            controller.error(new Error("Ifc statement exceeds maximum length"));
+          }
+        }
+      },
 
-          case "data":
-            {
-              if (line.trim() === "ENDSEC;") {
-                section = "footer";
-                return;
-              }
-              const result = extractLineMeta(line);
-              if (!result) {
-                controller.error(`Ifc corrupted line: ${line}`);
-                return;
-              }
-              const factory = getFactory(result.type);
-              if (!factory) {
-                controller.error(`Unknown Ifc type '${result.type}'`);
-                return;
-              }
-              const entity = factory(line);
-              entity.expressID = result.id;
-              controller.enqueue(entity);
-            }
-            break;
-
-          default:
-            break;
+      flush(controller) {
+        // reaching the end of input before END-ISO-10303-21; means the file
+        // is truncated or not an IFC file at all
+        if (statement.trim() || section !== "end") {
+          controller.error(new Error("Unexpected end of Ifc stream"));
         }
       },
     });

--- a/packages/fragments/src/Utils/ifc-stream.ts
+++ b/packages/fragments/src/Utils/ifc-stream.ts
@@ -1,3 +1,7 @@
+// eslint-disable-next-line max-classes-per-file
+import * as webIfc from "web-ifc";
+import { extractLineMeta, parseStepArguments } from "./ifc-parsing-utils";
+
 const crCharCode = 13; // "\r";
 const nl = "\n";
 
@@ -63,6 +67,107 @@ export class IfcDecoderStream extends TransformStream<Uint8Array, string> {
         const remaining = decoder.decode();
         const full = tail + remaining;
         if (full) controller.enqueue(full);
+      },
+    });
+  }
+}
+
+/**
+ *
+ * @example
+ * ```ts
+ * let blob: Blob;
+ *
+ * // node
+ * blob = await fs.openAsBlob(path, { type: "text/plain" });
+ *
+ * const ifcStream = blob
+ *   .stream()
+ *   .pipeThrough(new IfcDecoderStream())
+ *   .pipeThrough(new IfcParserStream());
+ *
+ * for await (const entity of ifcStream) {
+ *   const localId = entity.expressID;
+ *   const type = entity.type;
+ * }
+ * ```
+ */
+export class IfcParserStream extends TransformStream<
+  string,
+  webIfc.IfcLineObject
+> {
+  constructor() {
+    let schemaFactoryMap: Record<number, (...args: unknown[]) => any> | null =
+      null;
+    let section: "header" | "data" | "footer" = "header";
+    const header: string[] = [];
+    const schemaRE = /FILE_SCHEMA\(+'?([^')]*)'?\)+;/;
+
+    function getFactory(type: string): ((line: string) => any) | null {
+      if (!schemaFactoryMap) return null;
+
+      const typeCode = (webIfc as Record<string, unknown>)[type];
+      if (typeof typeCode !== "number") return null;
+
+      const ctor = schemaFactoryMap[typeCode];
+      if (!ctor) return null;
+
+      return (line: string) => {
+        const args = parseStepArguments(line);
+        return ctor(args);
+      };
+    }
+
+    super({
+      transform(line, controller) {
+        switch (section) {
+          case "header":
+            if (line.trim() === "DATA;") {
+              const schemaLine = header.find((line) => schemaRE.test(line));
+              const schema = schemaLine && schemaRE.exec(schemaLine)?.[1];
+              if (!schema) {
+                controller.error("Ifc schema not found");
+                return;
+              }
+              const schemaIndex = webIfc.SchemaNames.findIndex((names) =>
+                names?.includes(schema),
+              );
+              if (schemaIndex === -1) {
+                controller.error(`Ifc schema '${schema}' not found`);
+                return;
+              }
+              schemaFactoryMap = webIfc.Constructors[schemaIndex];
+              section = "data";
+              return;
+            }
+            header.push(line);
+            break;
+
+          case "data":
+            {
+              if (line.trim() === "ENDSEC;") {
+                section = "footer";
+                return;
+              }
+              const result = extractLineMeta(line);
+              if (!result) {
+                controller.error(`Ifc corrupted line: ${line}`);
+                return;
+              }
+              const factory = getFactory(result.type);
+              if (!factory) {
+                controller.error(`Unknown Ifc type '${result.type}'`);
+                return;
+              }
+              const entity = factory(line);
+              entity.expressID = result.id;
+              controller.enqueue(entity);
+            }
+            break;
+
+          default:
+            break;
+        }
       },
     });
   }

--- a/packages/fragments/src/Utils/index.ts
+++ b/packages/fragments/src/Utils/index.ts
@@ -11,3 +11,5 @@ export * from "./ifc-geometries-map";
 export * from "./ifc-relations-map";
 export * from "./worker-utils";
 export * from "./ifc-splitter";
+export * from "./ifc-parsing-utils";
+export * from "./ifc-stream";


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Introduce an ifc parser stream parsing the decoded row
Built on top of #197 

### Additional context

I think it will do good to the code's readability to use this instead of raw parser functions (if there is no perf hit) and it align internals to web-ifc achieving parity.
e.g. The splitter is not very readable (and therefore not very maintainable).

The PR introduces some parsing utils. IMO they should be abstracted and unified with existing parsing utils so there is a single function that parses a row and serves all use cases.


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
