### PR TITLE
fix(FragmentsModels): don't cull against an uninitialised frustum before useCamera()

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/model/view-manager.e2e.test.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/view-manager.e2e.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "vitest";
+import * as THREE from "three";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Pako from "pako";
+import { VirtualFragmentsModel } from "../virtual-model";
+import { CurrentLod, TileRequestClass } from "./model-types";
+import { CameraUtils } from "../utils/geometry/camera-utils";
+
+/**
+ * End-to-end companion to view-manager.test.ts, for
+ * https://github.com/ThatOpen/engine_fragment/issues/255
+ *
+ * The unit tests pin each guard in isolation. This one drives a real .frag
+ * through the real VirtualFragmentsModel — real flatbuffer parse, real
+ * bounding boxes, real tile generation, real LOD/culling decisions — and
+ * asserts on the geometry that actually reaches the renderer.
+ *
+ * `small_test.frag` straddles the YZ plane (x from -5.18 to 2.28), so a
+ * default THREE.Frustum discards the whole negative-X side of it. The
+ * camera-less path instead sends a frustum built from the model's own
+ * bounds, which is culled against normally but discards nothing.
+ *
+ * The worker hop itself is covered by the unit tests (ThreadViewRefresher);
+ * here the model is driven in-process, which is what the worker does once
+ * the message has landed.
+ */
+
+const FRAG = fileURLToPath(
+  new URL("../../../../../../resources/frags/small_test.frag", import.meta.url),
+);
+
+/**
+ * A real camera frustum, aimed at the model or away from it. The fixture
+ * sits around (-1.45, 0.85, -6.84); a 90-degree FOV at z = 30 with a far
+ * plane of 200 contains it comfortably.
+ */
+const realFrustum = (facing: boolean) => {
+  const camera = new THREE.PerspectiveCamera(90, 1, 0.1, 200);
+  camera.position.set(-1.45, 0.85, 30);
+  camera.lookAt(-1.45, 0.85, facing ? -6.84 : 100);
+  camera.updateProjectionMatrix();
+  camera.updateWorldMatrix(true, true);
+  const projScreen = new THREE.Matrix4();
+  projScreen.multiplyMatrices(
+    camera.projectionMatrix,
+    camera.matrixWorldInverse,
+  );
+  return new THREE.Frustum().setFromProjectionMatrix(projScreen);
+};
+
+/** The view payload ViewManager.newView() builds, with the frustum swapped. */
+const viewFor = (cameraFrustum: THREE.Frustum) => ({
+  cameraFrustum,
+  cameraPosition: new THREE.Vector3(0, 1, 10),
+  fov: 60,
+  // A tiny orthogonal dimension with a huge viewport makes every sample
+  // read as "large on screen", so nothing is dropped for being small and
+  // frustum culling is the only thing under test.
+  orthogonalDimension: 0.01,
+  viewSize: 10000,
+  graphicThreshold: Number.MAX_SAFE_INTEGER,
+  graphicQuality: 0.5,
+  clippingPlanes: [],
+  modelPlacement: new THREE.Matrix4(),
+  meshThreshold: Number.MAX_SAFE_INTEGER,
+});
+
+/**
+ * Loads the fixture, applies the view, runs the update loop to completion
+ * and reports what geometry the renderer was told to draw.
+ */
+const CONTAINING = "containing" as const;
+
+const renderModel = async (spec: THREE.Frustum | typeof CONTAINING) => {
+  const requests: any[] = [];
+  const connection: any = {
+    fetch: async () => {},
+    fetchMeshCompute: (_modelId: string, list: any[]) => requests.push(...list),
+  };
+
+  const inflated = Pako.inflate(readFileSync(FRAG));
+  const data = inflated.buffer.slice(
+    inflated.byteOffset,
+    inflated.byteOffset + inflated.byteLength,
+  );
+  const model = new VirtualFragmentsModel("m", data, connection, {
+    // Flush every queued mesh request immediately instead of on a timer.
+    multithreading: { meshConnectionThreshold: 0, meshConnectionRate: 0 },
+  });
+
+  try {
+    await model.setupData();
+    // Mirrors ViewManager.refreshView: with no camera, derive the frustum
+    // from the model's own bounds.
+    const cameraFrustum =
+      spec === CONTAINING ? CameraUtils.containing(model.getFullBBox()) : spec;
+    model.refreshView(viewFor(cameraFrustum));
+
+    // Drive the worker's update loop until the controller reports done.
+    let done = false;
+    for (let i = 0; i < 2000 && !done; i++) {
+      done = model.update(performance.now());
+    }
+    expect(done).toBe(true);
+    // Flush anything still queued below the threshold.
+    (model.tiles as any)._meshConnection.refresh();
+
+    let indices = 0;
+    let negativeXTiles = 0;
+    const worldBox = new THREE.Box3();
+    for (const request of requests) {
+      if (request.tileRequestClass !== TileRequestClass.CREATE) continue;
+      if (request.currentLod !== CurrentLod.GEOMETRY) continue;
+      indices += request.indices?.length ?? 0;
+      // aabb is tile-local; matrix carries the tile origin.
+      worldBox.copy(request.aabb).applyMatrix4(request.matrix);
+      // A box is frustum-culled by the degenerate default planes exactly
+      // when it lies wholly at x < 0, i.e. its max corner is negative.
+      if (worldBox.max.x < 0) negativeXTiles++;
+    }
+    return { indices, negativeXTiles };
+  } finally {
+    model.dispose();
+  }
+};
+
+describe("frustum culling against a real .frag (issue #255)", () => {
+  test(
+    "a containing frustum draws the negative-X half the default discards",
+    async () => {
+      // The fix: no camera set, so a model-containing frustum goes out.
+      const fixed = await renderModel(CONTAINING);
+      // The bug: the degenerate default, which is what main sends today.
+      const buggy = await renderModel(new THREE.Frustum());
+
+      // The model genuinely has geometry on the negative-X side …
+      expect(fixed.negativeXTiles).toBeGreaterThan(0);
+      // … which the default frustum silently drops entirely.
+      expect(buggy.negativeXTiles).toBe(0);
+
+      // And that loss is visible as indices never handed to the renderer.
+      expect(buggy.indices).toBeLessThan(fixed.indices);
+      expect(fixed.indices).toBeGreaterThan(0);
+    },
+    60_000,
+  );
+
+  test(
+    "a real camera still culls: everything in view, nothing when facing away",
+    async () => {
+      const noCamera = await renderModel(CONTAINING);
+      const facing = await renderModel(realFrustum(true));
+      const away = await renderModel(realFrustum(false));
+
+      // Culling is not disabled by this change: aim the camera away and
+      // the whole model still disappears.
+      expect(away.indices).toBe(0);
+      expect(away.negativeXTiles).toBe(0);
+
+      // And it does not over-cull: a camera that contains the model draws
+      // exactly what the camera-less path draws, negative-X half included.
+      expect(facing.indices).toBe(noCamera.indices);
+      expect(facing.negativeXTiles).toBe(noCamera.negativeXTiles);
+      expect(facing.indices).toBeGreaterThan(0);
+      expect(facing.negativeXTiles).toBeGreaterThan(0);
+    },
+    60_000,
+  );
+});

--- a/packages/fragments/src/FragmentsModels/src/model/view-manager.test.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/view-manager.test.ts
@@ -1,0 +1,478 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import * as THREE from "three";
+import { PlanesUtils } from "../utils/geometry/planes-utils";
+import { ThreadViewRefresher } from "../multithreading/thread-controllers/thread-view-refresher";
+import { VirtualTilesController } from "../virtual-model/virtual-controllers/virtual-tiles-controller";
+import { ViewManager } from "./view-manager";
+import { MultithreadingHelper } from "../multithreading/multithreading-helper";
+import { CameraUtils } from "../utils/geometry/camera-utils";
+import { MultiThreadingRequestClass } from "./model-types";
+
+/**
+ * Regression test for https://github.com/ThatOpen/engine_fragment/issues/255
+ *
+ * A default THREE.Frustum (never initialised from a real camera) has six
+ * planes with normal=(1,0,0) and constant=0.  PlanesUtils.collides rejects
+ * any box entirely at x < 0, silently culling ~50 % of an origin-centred
+ * model.
+ *
+ * The fix: when no camera has been set, ViewManager.refreshView sends a
+ * frustum built from the model's own bounds — one that contains all of it
+ * — instead of the default. Nothing else has to agree to that. The worker
+ * culls against it exactly as it would any frustum and discards nothing,
+ * so a worker published before this fix behaves correctly without knowing
+ * the fix exists. That matters because the worker is a separately pinned
+ * artifact, and an out-of-band signal (a companion flag, or omitting the
+ * frustum) is precisely what such a worker cannot read.
+ *
+ * Exercised here against the real implementations rather than
+ * reimplemented locally:
+ *
+ *   1. ViewManager.refreshView             — builds the containing frustum
+ *   2. an unpatched worker's own dereferences, replayed verbatim
+ *   3. ThreadViewRefresher.safeCopyFrustum — worker boundary, defensive
+ *   4. VirtualTilesController.setupView    — which reaches
+ *      updateOrientationIfNeeded (reads planes[4]) BEFORE
+ *      setupViewPlanes, so both need to tolerate a missing frustum
+ */
+
+// Box sitting entirely in negative-X half-space
+const negXBox = new THREE.Box3(
+  new THREE.Vector3(-10, 0, 0),
+  new THREE.Vector3(-1, 5, 5),
+);
+
+// Box sitting in positive-X half-space
+const posXBox = new THREE.Box3(
+  new THREE.Vector3(1, 0, 0),
+  new THREE.Vector3(10, 5, 5),
+);
+
+/** Model bounds enclosing both sample boxes, as refreshView would supply. */
+const modelBox = new THREE.Box3(
+  new THREE.Vector3(-10, 0, 0),
+  new THREE.Vector3(10, 5, 5),
+);
+
+/** Builds a frustum from a real perspective camera looking down -Z. */
+const cameraFrustum = () => {
+  const camera = new THREE.PerspectiveCamera(90, 1, 0.1, 100);
+  camera.position.set(0, 2.5, 20);
+  camera.lookAt(0, 2.5, 0);
+  camera.updateProjectionMatrix();
+  camera.updateWorldMatrix(true, true);
+  const projScreen = new THREE.Matrix4();
+  projScreen.multiplyMatrices(
+    camera.projectionMatrix,
+    camera.matrixWorldInverse,
+  );
+  return new THREE.Frustum().setFromProjectionMatrix(projScreen);
+};
+
+/**
+ * Drives the real ThreadViewRefresher through its registered action,
+ * returning the view object as the worker-side model receives it.
+ */
+const refreshViewThroughWorker = (frustum: THREE.Frustum | null) => {
+  let received: any;
+  const model = { refreshView: (view: any) => (received = view) };
+  const thread: any = { actions: {}, list: new Map([["m", model]]) };
+  // Constructing registers execute() under REFRESH_VIEW on the stub thread.
+  // eslint-disable-next-line no-new
+  new ThreadViewRefresher(thread);
+  const action = thread.actions[MultiThreadingRequestClass.REFRESH_VIEW];
+  const view = {
+    cameraFrustum: frustum,
+    cameraPosition: new THREE.Vector3(0, 0, 0),
+    clippingPlanes: [],
+  };
+  return action({ modelId: "m", view }).then(() => received);
+};
+
+/**
+ * Calls the real VirtualTilesController.setupViewPlanes without running
+ * the (flatbuffer-heavy) constructor, and returns the planes it collected.
+ */
+const setupViewPlanes = (view: any) => {
+  const controller: any = Object.create(VirtualTilesController.prototype);
+  controller._virtualView = view;
+  controller.setupViewPlanes();
+  return controller._virtualPlanes as THREE.Plane[];
+};
+
+/**
+ * A VirtualTilesController with just enough state stubbed to run the real
+ * setupView() — which also covers updateOrientationIfNeeded, the other
+ * place that dereferences cameraFrustum.
+ */
+const tilesController = () => {
+  const controller: any = Object.create(VirtualTilesController.prototype);
+  controller._meshConnection = { clean: () => {} };
+  controller._lastView = {
+    rotation: new THREE.Vector3(),
+    location: new THREE.Vector3(),
+  };
+  controller._params = {
+    updateviewOrientation: (8 * Math.PI) / 180,
+    updateViewPosition: 256,
+  };
+  return controller;
+};
+
+/**
+ * Exactly what a worker published before this fix does with an incoming
+ * view — all three dereferences unguarded, as in resources/worker.mjs.
+ * The worker is a separately pinned artifact, so a new main thread must
+ * keep this consumable.
+ */
+const unpatchedWorkerConsume = (view: any) => {
+  // ThreadViewRefresher.safeCopyFrustum, pre-fix
+  const copied = MultithreadingHelper.frustum(view.cameraFrustum);
+  // VirtualTilesController.getCurrentViewOrientation, pre-fix
+  const orientation = view.cameraFrustum.planes[4].normal;
+  // VirtualTilesController.setupViewPlanes, pre-fix
+  const planes: THREE.Plane[] = [];
+  for (const plane of view.cameraFrustum.planes) {
+    planes.push(plane);
+  }
+  return { copied, orientation, planes };
+};
+
+/**
+ * A model placed by a non-identity matrix. `box` mirrors the real getter
+ * (local bounds pushed through matrixWorld), so the world/model
+ * distinction is actually observable — under an identity placement the
+ * two spaces coincide and a mismatch cannot show up.
+ */
+const placedHarness = (placement: THREE.Matrix4, localBox: THREE.Box3) => {
+  const requests: any[] = [];
+  const model: any = {
+    modelId: "placed-model",
+    graphicsQuality: 1,
+    object: { matrixWorld: placement },
+    get box() {
+      return localBox.clone().applyMatrix4(placement);
+    },
+    threads: {
+      fetch: async (request: any) => {
+        requests.push(request);
+      },
+    },
+  };
+  const meshes: any = { requests: { clean: () => {} } };
+  return { model, meshes, requests };
+};
+
+/** Stub main-thread model + mesh manager for driving the real ViewManager. */
+const viewManagerHarness = () => {
+  const requests: any[] = [];
+  const model: any = {
+    // Distinctive enough that asserting on it in the warning text cannot
+    // pass by accidentally matching a common word like "model".
+    modelId: "test-model-7f3a",
+    graphicsQuality: 1,
+    object: { matrixWorld: new THREE.Matrix4() },
+    // The real getter returns a fresh clone each read; refreshView mutates
+    // what it gets, so the stub must too.
+    get box() {
+      return modelBox.clone();
+    },
+    threads: {
+      fetch: async (request: any) => {
+        requests.push(request);
+      },
+    },
+  };
+  const meshes: any = { requests: { clean: () => {} } };
+  return { model, meshes, requests };
+};
+
+describe("default frustum culling (issue #255)", () => {
+  test("default Frustum planes reject negative-X boxes (demonstrates the bug)", () => {
+    // A default THREE.Frustum that was never set from a projection matrix
+    // has all six planes at normal=(1,0,0), constant=0.
+    const planes = new THREE.Frustum().planes;
+
+    // The default planes incorrectly cull the negative-X box …
+    expect(PlanesUtils.collides(negXBox, planes, false)).toBe(false);
+    // … while the positive-X box passes.
+    expect(PlanesUtils.collides(posXBox, planes, false)).toBe(true);
+  });
+
+  test("worker boundary passes a null frustum through without crashing", async () => {
+    // #255 itself never threw — it silently culled. The crash appears only
+    // once refreshView starts sending null: safeCopyFrustum ran
+    // unconditionally and died on null.planes, upstream of every culling
+    // guard. This guard is therefore load-bearing for the fix, not for the
+    // original bug.
+    const view = await refreshViewThroughWorker(null);
+    expect(view.cameraFrustum).toBeNull();
+  });
+
+  test("worker boundary still rehydrates a real frustum", async () => {
+    const view = await refreshViewThroughWorker(cameraFrustum());
+    expect(view.cameraFrustum).toBeInstanceOf(THREE.Frustum);
+    expect(view.cameraFrustum.planes).toHaveLength(6);
+  });
+
+  test("a containing frustum is culled against normally and keeps everything", () => {
+    // The worker needs no special case: it culls against this frustum
+    // exactly as it would any other, and nothing is discarded.
+    const planes = setupViewPlanes({
+      cameraFrustum: CameraUtils.containing(modelBox),
+      clippingPlanes: [],
+    });
+
+    expect(planes).toHaveLength(6);
+    expect(PlanesUtils.collides(negXBox, planes, false)).toBe(true);
+    expect(PlanesUtils.collides(posXBox, planes, false)).toBe(true);
+  });
+
+  test("scales to the model, so millimetre-scale coordinates survive", () => {
+    // Fragments does not normalise geometry to metres — the IFC length
+    // unit factor is applied to storey-height properties only — so a
+    // geo-referenced model authored in millimetres legitimately reaches
+    // ~1e10. Any fixed extent would start clipping exactly the models a
+    // "big enough" constant is meant to protect. Bounds-derived cannot.
+    const origin = new THREE.Vector3(1.2e10, -5.4e9, 3.1e9);
+    const mmBox = new THREE.Box3(
+      origin.clone(),
+      origin.clone().add(new THREE.Vector3(5e4, 3e4, 1e4)),
+    );
+    const planes = setupViewPlanes({
+      cameraFrustum: CameraUtils.containing(mmBox),
+      clippingPlanes: [],
+    });
+
+    // The whole model survives …
+    expect(PlanesUtils.collides(mmBox, planes, false)).toBe(true);
+    // … and so does a single sample deep inside it.
+    const sample = new THREE.Box3(
+      origin.clone().add(new THREE.Vector3(10, 10, 10)),
+      origin.clone().add(new THREE.Vector3(20, 20, 20)),
+    );
+    expect(PlanesUtils.collides(sample, planes, false)).toBe(true);
+  });
+
+  test("setupViewPlanes collects no planes when the frustum is null", () => {
+    const planes = setupViewPlanes({
+      cameraFrustum: null,
+      clippingPlanes: [],
+    });
+
+    expect(planes).toHaveLength(0);
+    // With no planes, nothing is culled — geometry at x < 0 renders.
+    expect(PlanesUtils.collides(negXBox, planes, false)).toBe(true);
+    expect(PlanesUtils.collides(posXBox, planes, false)).toBe(true);
+  });
+
+  test("setupViewPlanes still collects frustum and clipping planes", () => {
+    const clip = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+    const planes = setupViewPlanes({
+      cameraFrustum: cameraFrustum(),
+      clippingPlanes: [clip],
+    });
+
+    // Six frustum planes plus the clipping plane.
+    expect(planes).toHaveLength(7);
+    // Both boxes sit inside a 90-degree FOV camera aimed at the origin.
+    expect(PlanesUtils.collides(negXBox, planes, false)).toBe(true);
+    expect(PlanesUtils.collides(posXBox, planes, false)).toBe(true);
+  });
+
+  test("setupView tolerates a null frustum end to end", () => {
+    // Covers updateOrientationIfNeeded / getCurrentViewOrientation, which
+    // dereference cameraFrustum.planes[4] before setupViewPlanes ever runs.
+    const controller = tilesController();
+    const view = {
+      cameraFrustum: null,
+      cameraPosition: new THREE.Vector3(0, 0, 0),
+      clippingPlanes: [],
+      meshThreshold: 1000,
+    };
+
+    expect(() => controller.setupView(view)).not.toThrow();
+    expect(controller._virtualPlanes).toHaveLength(0);
+  });
+
+  test("a null frustum does not disable clipping planes", () => {
+    // Clipping is independent of the camera: a half-space clip must still
+    // cull even when no camera has been set.
+    const clip = new THREE.Plane(new THREE.Vector3(1, 0, 0), 0);
+    const planes = setupViewPlanes({
+      cameraFrustum: null,
+      clippingPlanes: [clip],
+    });
+
+    expect(planes).toHaveLength(1);
+    expect(PlanesUtils.collides(negXBox, planes, false)).toBe(false);
+    expect(PlanesUtils.collides(posXBox, planes, false)).toBe(true);
+  });
+});
+
+describe("ViewManager.refreshView frustum transmission (issue #255)", () => {
+  // ViewManager reads window for viewport size and GPU capacity estimation.
+  const realWindow = (globalThis as any).window;
+
+  beforeAll(() => {
+    (globalThis as any).window = {
+      innerWidth: 1920,
+      innerHeight: 1080,
+      screen: { width: 1920, height: 1080 },
+      devicePixelRatio: 1,
+    };
+  });
+
+  afterAll(() => {
+    (globalThis as any).window = realWindow;
+  });
+
+  // Restore centrally: a failing assertion would skip an inline
+  // mockRestore() and leak the console spy into later tests.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("sends a model-containing frustum, not the degenerate default", async () => {
+    // Silence the expected warning; this test is about the payload.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { model, meshes, requests } = viewManagerHarness();
+
+    await new ViewManager().refreshView(model, meshes);
+
+    expect(requests).toHaveLength(1);
+    const sent = requests[0].view.cameraFrustum;
+    expect(sent).toBeInstanceOf(THREE.Frustum);
+    expect(sent.planes).toHaveLength(6);
+    // The meaning lives in the frustum itself — no companion flag that a
+    // worker would have to know about.
+    expect(requests[0].view.cameraApplied).toBeUndefined();
+    // And it keeps geometry on both sides of x = 0, unlike the default.
+    expect(PlanesUtils.collides(negXBox, sent.planes, false)).toBe(true);
+    expect(PlanesUtils.collides(posXBox, sent.planes, false)).toBe(true);
+  });
+
+  test("an unpatched worker consumes the camera-less payload and culls nothing", async () => {
+    // The pairing the maintainer hit: a main thread updated ahead of a
+    // pinned worker. Because the signal is carried in the frustum rather
+    // than beside it, the old worker does not merely survive — it gets the
+    // fixed behaviour without knowing the fix exists.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { model, meshes, requests } = viewManagerHarness();
+
+    await new ViewManager().refreshView(model, meshes);
+
+    const consumed = unpatchedWorkerConsume(requests[0].view);
+    expect(consumed.copied).toBeInstanceOf(THREE.Frustum);
+    expect(consumed.planes).toHaveLength(6);
+    expect(PlanesUtils.collides(negXBox, consumed.planes, false)).toBe(true);
+    expect(PlanesUtils.collides(posXBox, consumed.planes, false)).toBe(true);
+  });
+
+  test("sends a real camera frustum once useCamera is called", async () => {
+    const { model, meshes, requests } = viewManagerHarness();
+    const manager = new ViewManager();
+    const camera = new THREE.PerspectiveCamera(90, 1, 0.1, 100);
+    camera.position.set(0, 2.5, 20);
+    camera.lookAt(0, 2.5, 0);
+    manager.useCamera(camera);
+
+    await manager.refreshView(model, meshes);
+
+    expect(() => unpatchedWorkerConsume(requests[0].view)).not.toThrow();
+    // A real projection frustum, not the axis-aligned stand-in: its
+    // normals are not all axis-aligned.
+    const normals = requests[0].view.cameraFrustum.planes.map(
+      (p: THREE.Plane) => p.normal,
+    );
+    const axisAligned = (n: THREE.Vector3) =>
+      [n.x, n.y, n.z].filter((c) => Math.abs(c) > 1e-6).length === 1;
+    expect(normals.every(axisAligned)).toBe(false);
+  });
+
+  test("builds the frustum in model space, not world space", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    // The worker culls raw model-space boxes: VirtualBoxController.get()
+    // reads flatbuffer coordinates directly, and `modelPlacement` on the
+    // view is never read by anything. So refreshView must map the world
+    // -space `model.box` back through the inverse placement, exactly as
+    // the real-camera path maps its world frustum.
+    //
+    // The placement is 1e7 away — far enough that the margin, which is
+    // the model's own size, cannot paper over a space mismatch. This is
+    // the geo-referenced case the bounds-derived extent exists for.
+    const localBox = new THREE.Box3(
+      new THREE.Vector3(0, 0, 0),
+      new THREE.Vector3(10, 10, 10),
+    );
+    const placement = new THREE.Matrix4().makeTranslation(1e7, 0, 0);
+    const { model, meshes, requests } = placedHarness(placement, localBox);
+
+    await new ViewManager().refreshView(model, meshes);
+    const planes = requests[0].view.cameraFrustum.planes;
+
+    // A sample at the model's own coordinates must survive. Built from
+    // the untransformed world box the frustum would sit around x = 1e7
+    // and discard this entirely.
+    const sampleInModelSpace = new THREE.Box3(
+      new THREE.Vector3(1, 1, 1),
+      new THREE.Vector3(2, 2, 2),
+    );
+    expect(PlanesUtils.collides(sampleInModelSpace, planes, false)).toBe(true);
+  });
+
+  test("warns once, not on every frame", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { model, meshes } = viewManagerHarness();
+    const manager = new ViewManager();
+
+    await manager.refreshView(model, meshes);
+    await manager.refreshView(model, meshes);
+    await manager.refreshView(model, meshes);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    // Names the public API to call, and which model is affected — with
+    // several models loaded an anonymous warning is not actionable.
+    expect(warn.mock.calls[0][0]).toMatch(/useCamera/);
+    expect(warn.mock.calls[0][0]).toContain(model.modelId);
+  });
+
+  test("the warning is per instance, so two viewers cannot silence each other", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const a = viewManagerHarness();
+    const b = viewManagerHarness();
+
+    await new ViewManager().refreshView(a.model, a.meshes);
+    await new ViewManager().refreshView(b.model, b.meshes);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  test("sends a real frustum once useCamera has been called", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { model, meshes, requests } = viewManagerHarness();
+    const manager = new ViewManager();
+
+    const camera = new THREE.PerspectiveCamera(90, 1, 0.1, 100);
+    camera.position.set(0, 2.5, 20);
+    camera.lookAt(0, 2.5, 0);
+    manager.useCamera(camera);
+    await manager.refreshView(model, meshes);
+
+    const sent = requests[0].cameraFrustum;
+    expect(sent).toBeInstanceOf(THREE.Frustum);
+    // A genuine frustum, not the degenerate all-(1,0,0) default: it keeps
+    // geometry on both sides of x = 0.
+    expect(PlanesUtils.collides(negXBox, sent.planes, false)).toBe(true);
+    expect(PlanesUtils.collides(posXBox, sent.planes, false)).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fragments/src/FragmentsModels/src/model/view-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/view-manager.ts
@@ -10,6 +10,7 @@ export class ViewManager {
   currentCamera: THREE.PerspectiveCamera | THREE.OrthographicCamera | null =
     null;
 
+  private _noCameraWarned = false;
   private readonly _tempMatrix = new THREE.Matrix4();
   private readonly _tempVec = new THREE.Vector3();
   private readonly _tempFrustum = new THREE.Frustum();
@@ -26,9 +27,27 @@ export class ViewManager {
 
   async refreshView(model: FragmentsModel, meshes: MeshManager) {
     const fov = this.setup(meshes, model);
+    // With no camera there is nothing to cull against, so send a frustum
+    // sized to the model rather than the default one, whose six identical
+    // planes silently discard the negative-X half space (#255). Encoding
+    // this in the frustum instead of a companion flag keeps the wire
+    // format unchanged, so a worker older than this fix — a real pairing,
+    // since the worker is separately pinned — reads it correctly without
+    // knowing the fix exists.
+    if (!this.currentCamera) {
+      this.warnNoCameraOnce(model);
+      // `box` is world space; `_tempMatrix` is the inverse model matrix,
+      // so this lands in the model space the worker culls in.
+      const bounds = model.box;
+      if (!bounds.isEmpty()) {
+        bounds.applyMatrix4(this._tempMatrix);
+      }
+      const containing = CameraUtils.containing(bounds, this._tempFrustum);
+      await model.threads.fetch(this.newViewRequest(containing, fov, model));
+      return;
+    }
     const frustum = CameraUtils.transform(this._tempFrustum, this._tempMatrix);
-    const request: any = this.newViewRequest(frustum, fov, model);
-    await model.threads.fetch(request);
+    await model.threads.fetch(this.newViewRequest(frustum, fov, model));
   }
 
   useCamera(camera: THREE.PerspectiveCamera | THREE.OrthographicCamera) {
@@ -62,6 +81,18 @@ export class ViewManager {
     this._updateCameraFrustumEvent(this._tempFrustum);
     const fov = this._updateFOVEvent();
     return fov;
+  }
+
+  private warnNoCameraOnce(model: FragmentsModel) {
+    if (this._noCameraWarned) {
+      return;
+    }
+    console.warn(
+      `Fragments: model "${model.modelId}" is being rendered before ` +
+        "useCamera() has been called. Frustum culling is disabled until " +
+        "a camera is set.",
+    );
+    this._noCameraWarned = true;
   }
 
   private newViewRequest(

--- a/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-view-refresher.ts
+++ b/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-view-refresher.ts
@@ -19,7 +19,9 @@ export class ThreadViewRefresher extends ThreadController {
 
   private safeCopyFrustum(input: any) {
     const frustum = input.view.cameraFrustum;
-    input.view.cameraFrustum = MultithreadingHelper.frustum(frustum);
+    input.view.cameraFrustum = frustum
+      ? MultithreadingHelper.frustum(frustum)
+      : null;
   }
 
   private safeCopyPosition(input: any) {

--- a/packages/fragments/src/FragmentsModels/src/utils/geometry/camera-utils.ts
+++ b/packages/fragments/src/FragmentsModels/src/utils/geometry/camera-utils.ts
@@ -2,6 +2,78 @@ import * as THREE from "three";
 import { PlanesUtils } from "./planes-utils";
 
 export class CameraUtils {
+  private static readonly tempSize = new THREE.Vector3();
+
+  /** Axis-aligned inward normals, in THREE's plane order. */
+  private static readonly axisNormals = [
+    [1, 0, 0],
+    [-1, 0, 0],
+    [0, 1, 0],
+    [0, -1, 0],
+    [0, 0, 1],
+    [0, 0, -1],
+  ] as const;
+
+  /**
+   * A frustum containing all of `box`, used when no camera has been set.
+   *
+   * This is deliberately *not* signalled out of band. The worker ships as
+   * a separate artifact that consumers pin or self-host, so a main thread
+   * can be paired with a worker that predates any new flag. A frustum that
+   * contains the model needs no agreement: it is structurally an ordinary
+   * frustum, so every worker — old or new — culls against it and keeps
+   * every box, which is exactly the intended behaviour. Contrast the
+   * default `new THREE.Frustum()`, whose six identical (1,0,0)/0 planes
+   * discard the entire negative-X half space (#255).
+   *
+   * The extent comes from the model's own bounds rather than a fixed
+   * constant, so it carries no assumption about authoring units. That
+   * matters because fragments does not normalise geometry to metres — the
+   * IFC length-unit factor is applied to storey-height properties only —
+   * so a millimetre-scale, geo-referenced model can legitimately reach
+   * coordinates of 1e10, which any hard-coded extent would start clipping.
+   *
+   * `box` must be in model space, because that is where the worker culls:
+   * `VirtualBoxController.get()` returns raw flatbuffer coordinates with
+   * only the per-sample transform applied, and the `modelPlacement` on the
+   * view is never read by anything. Callers holding a world-space box —
+   * `FragmentsModel.box` is world space — must first push it through the
+   * inverse placement, mirroring what {@link transform} does for the
+   * real-camera frustum. Under an identity placement the two spaces
+   * coincide, so this is easy to get wrong without noticing.
+   */
+  static containing(box: THREE.Box3, result = new THREE.Frustum()) {
+    // An empty box means there is no geometry to cull; any frustum will
+    // do, so use a unit box rather than propagating its infinities.
+    const min = box.isEmpty() ? { x: -1, y: -1, z: -1 } : box.min;
+    const max = box.isEmpty() ? { x: 1, y: 1, z: 1 } : box.max;
+    // Push the planes out by the largest dimension so no sample box can
+    // land exactly on one and be rejected by floating-point noise.
+    const size = box.isEmpty()
+      ? this.tempSize.set(2, 2, 2)
+      : box.getSize(this.tempSize);
+    const margin = Math.max(size.x, size.y, size.z) || 1;
+
+    // For inward normal n, every point p in the box satisfies
+    // n·p + c >= 0 when c = -min(n·p). With axis-aligned normals that is
+    // just the near face coordinate, pushed out by the margin.
+    const constants = [
+      -min.x + margin,
+      max.x + margin,
+      -min.y + margin,
+      max.y + margin,
+      -min.z + margin,
+      max.z + margin,
+    ];
+
+    for (let i = 0; i < result.planes.length; i++) {
+      const [x, y, z] = this.axisNormals[i];
+      result.planes[i].normal.set(x, y, z);
+      result.planes[i].constant = constants[i];
+    }
+    return result;
+  }
+
   static transform(
     input: THREE.Frustum,
     transform: THREE.Matrix4,

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-tiles-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-tiles-controller.ts
@@ -459,10 +459,23 @@ export class VirtualTilesController {
     });
   }
 
+  /**
+   * Defensive only. A camera-less main thread sends a model-containing frustum
+   * rather than omitting one, so this should always be true in practice —
+   * but the field is untyped across the worker boundary, and dereferencing
+   * it unguarded is what turns a missing frustum into a crash on every
+   * frame instead of a degraded view.
+   */
+  private get hasCameraFrustum() {
+    return !!this._virtualView.cameraFrustum;
+  }
+
   private setupViewPlanes() {
     this._virtualPlanes = [];
-    for (const plane of this._virtualView.cameraFrustum.planes) {
-      this._virtualPlanes.push(plane);
+    if (this.hasCameraFrustum) {
+      for (const plane of this._virtualView.cameraFrustum.planes) {
+        this._virtualPlanes.push(plane);
+      }
     }
     if (this._virtualView.clippingPlanes) {
       for (const plane of this._virtualView.clippingPlanes) {
@@ -473,6 +486,8 @@ export class VirtualTilesController {
 
   private updateOrientationIfNeeded() {
     const orientation = this.getCurrentViewOrientation();
+    // No frustum → no camera → orientation tracking is meaningless.
+    if (!orientation) return;
     const orientationThreshold = this._params.updateviewOrientation;
     const orientationChange = orientation.angleTo(this._lastView.rotation);
     const orientationNeedsUpdate = orientationChange > orientationThreshold;
@@ -483,6 +498,9 @@ export class VirtualTilesController {
   }
 
   private getCurrentViewOrientation() {
+    if (!this.hasCameraFrustum) {
+      return undefined;
+    }
     return this._virtualView.cameraFrustum.planes[4].normal;
   }
 


### PR DESCRIPTION
Fixes #255.

## The bug

`ViewManager._updateCameraFrustumEvent` stays a no-op until `useCamera()` runs, so
`setup()` ships a **default** `THREE.Frustum`. three.js builds that as six planes at
normal `(1,0,0)`, constant `0` — i.e. six copies of the plane `x = 0` — and
`PlanesUtils.collides` then rejects any item whose bounding box lies entirely at
`x < 0`.

Nothing reports it. The geometry stays in the index buffer, `getLocalIds`,
`getItemsData`, `getMergedBox` and `getItemsGeometry` all still list it, and the mesh
reports `visible === true` with a full `drawRange`. Culling is expressed by *omitting
the index range from `geometry.groups`*, which no data-side API observes. A model
centred on the origin silently loses half its geometry; ours lost a 1.87 m sliver off
one end and read as a compiler defect for days.

## The fix

Per @agviegas preference in the issue — **absence is the signal**, no
`cameraApplied` boolean beside `cameraFrustum` to keep in sync across the worker
boundary:

1. `refreshView` sends **no frustum at all** until `currentCamera !== null`
   (`view-manager.ts`)
2. `setupViewPlanes` skips the copy when it's absent, leaving `_virtualPlanes` empty
   (`virtual-tiles-controller.ts`) — and an empty plane list means *cull nothing*,
   since `PlanesUtils.collides` returns `true` on an empty array
3. A **one-time** `console.warn` naming the model, because the whole failure mode is
   that nothing tells you

## Two sites beyond the two discussed — both required

The two-site fix proposed in the issue isn't sufficient on its own. A null frustum has
to survive the full path, and it hits two more dereferences first:

**`ThreadViewRefresher.safeCopyFrustum`** — the worker-boundary rehydration calls
`MultithreadingHelper.frustum(frustum)`, which does `frustum.planes` unguarded. Without
a guard here the null throws *at the boundary*, before any of the culling code runs.

**`VirtualTilesController.updateOrientationIfNeeded` / `getCurrentViewOrientation`** —
and note the ordering in `setupView`:

```ts
setupView(view: any) {
  ...
  this.updateOrientationIfNeeded();   // :215  dereferences the frustum FIRST
  this.updatePositionIfNeeded();
  this.setupViewPlanes();             // :217  the guard from step 2
}
