### PR TITLE
fix(split): visited reporting non existing refs

### DIFF
--- a/packages/fragments/src/Utils/ifc-splitter/index.test.ts
+++ b/packages/fragments/src/Utils/ifc-splitter/index.test.ts
@@ -123,6 +123,41 @@ test("extract releases the output writer when the write pass fails", async () =>
   expect(io.sinks.get("out.ifc")?.closed).toBe(false);
 });
 
+// Regression: `collectDeps` marked an id visited BEFORE looking up its refs, so
+// an id that is only ever referenced — never defined by a line of its own — was
+// reported in the group's id set. It cannot be, since nothing is written for it.
+test("split never reports an id the source does not define", async () => {
+  const source = [
+    "ISO-10303-21;",
+    "HEADER;",
+    "ENDSEC;",
+    "DATA;",
+    // Dangling reference: no line defines #999.
+    "#1=IFCWALL('guid1',$,$,$,$,#999,$,$);",
+    // '#' inside a quoted string, which the ref scanner reads as a reference.
+    "#2=IFCWALL('guid2 (see #99999)',$,$,$,$,$,$,$);",
+    "ENDSEC;",
+    "END-ISO-10303-21;",
+  ].join("\n");
+  const defined = new Set(
+    [...source.matchAll(/^#(\d+)=/gm)].map((m) => Number(m[1])),
+  );
+  const io = new MemoryIO(source);
+  const splitter = new IfcSplitter(io);
+
+  const splitMap = await splitter.split(
+    "in.ifc",
+    2,
+    (groupId) => `out_${groupId}.ifc`,
+  );
+
+  expect(splitMap.size).toBe(2);
+  for (const [groupId, { ids }] of splitMap) {
+    const undefined_ = [...ids].filter((id) => !defined.has(id));
+    expect(undefined_, `group ${groupId} reports undefined ids`).toEqual([]);
+  }
+});
+
 // Regression: group membership used to live in a `1 << g` bitmask over a
 // Uint32Array, so group 32 aliased group 0, group 33 aliased group 1, and so
 // on — silently duplicating elements into the wrong output files.

--- a/packages/fragments/src/Utils/ifc-splitter/index.ts
+++ b/packages/fragments/src/Utils/ifc-splitter/index.ts
@@ -324,9 +324,13 @@ function collectDeps(
   while (stack.length > 0) {
     const id = stack.pop()!;
     if (visited.has(id)) continue;
-    visited.add(id);
     const refs = index.getRefs(id);
+    // No refs entry means no line defines this id: it was only ever REFERENCED,
+    // by a dangling `#N` or by a `#` inside a quoted string. Nothing is written
+    // for it, so it must not enter `visited` — that set is the group's id list,
+    // reported to the caller and used to size id-indexed maps.
     if (!refs) continue;
+    visited.add(id);
     for (let i = 0; i < refs.length; i++) {
       const refId = refs[i];
       if (visited.has(refId)) continue;
@@ -345,9 +349,10 @@ function collectDepsAll(
   while (stack.length > 0) {
     const id = stack.pop()!;
     if (visited.has(id)) continue;
-    visited.add(id);
     const refs = index.getRefs(id);
+    // Undefined id — see collectDeps.
     if (!refs) continue;
+    visited.add(id);
     for (let i = 0; i < refs.length; i++) {
       if (!visited.has(refs[i])) stack.push(refs[i]);
     }


### PR DESCRIPTION
# `IfcSplitter.split()` reports ids that no line in the file defines

Caught when reviewing code with claude.

## My take 
I believe this is why the parser should use web-ifc instead of re-inventing the wheel - and address perf using the stream parser #252  and other dedicated fixes

## Summary

`split()` returns `Map<groupId, { path, ids }>`. The `ids` set includes express ids that are **not written to the output file and do not exist in the input file at all** — ids that only ever appeared as a *reference*, never as an entity definition.

`extract()` is affected the same way; it shares `collectDeps`.

## Reproduction

Self-contained, public API only:

```ts
import { IfcSplitter } from "@thatopen/fragments";
import { readFileSync, writeFileSync } from "node:fs";

const io = {
  async readableStream(p: string) {
    const lines = readFileSync(p, "utf-8").split("\n");
    return new ReadableStream<string>({
      start(c) { for (const l of lines) c.enqueue(l); c.close(); },
    });
  },
  async writableStream(p: string) {
    const out: string[] = [];
    return new WritableStream<string>({
      write: (chunk) => void out.push(chunk),
      close: () => writeFileSync(p, out.join("\n")),
    });
  },
};

writeFileSync("in.ifc", `ISO-10303-21;
HEADER;
FILE_DESCRIPTION((''),'2;1');
FILE_SCHEMA(('IFC4'));
ENDSEC;
DATA;
#1=IFCPROJECT('p',$,'Project',$,$,$,$,$,$);
#2=IFCSITE('s',$,'Site',$,$,$,$,$,$,$,$,$,$,$);
#3=IFCBUILDING('b',$,'Building',$,$,$,$,$,$,$,$,$);
#4=IFCBUILDINGSTOREY('st',$,'Storey',$,$,$,$,$,$,$);
#5=IFCRELAGGREGATES('r1',$,$,$,#1,(#2));
#6=IFCRELAGGREGATES('r2',$,$,$,#2,(#3));
#7=IFCRELAGGREGATES('r3',$,$,$,#3,(#4));
#10=IFCCARTESIANPOINT((0.,0.,0.));
#11=IFCPRODUCTDEFINITIONSHAPE($,$,(#10));
#12=IFCWALL('wa',$,'Wall A',$,$,#999,#11,$,$);
#13=IFCCARTESIANPOINT((1.,0.,0.));
#14=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
#15=IFCWALL('wb',$,'Wall B (see #99999)',$,$,$,#14,$,$);
#17=IFCRELCONTAINEDINSPATIALSTRUCTURE('rc',$,$,$,(#12,#15),#4);
ENDSEC;
END-ISO-10303-21;
`);

const result = await new IfcSplitter(io).split("in.ifc", 2, (g) => `out_${g}.ifc`);
for (const [groupId, { ids }] of result) {
  console.log(groupId, [...ids].sort((a, b) => a - b).join(","));
}
```

Two ways to trigger it, one in each wall:

- `#12` holds `#999` in an attribute slot — a reference to a line the file never defines (ordinary in exports that drop entities).
- `#15` has `#99999` inside a **quoted string**, `'Wall B (see #99999)'`.

### Actual

```
group 0: 1,2,3,4,5,6,7,10,11,12,17,999
group 1: 1,2,3,4,5,6,7,13,14,15,17,99999
```

The highest id defined anywhere in the input is **17**. Neither `999` nor `99999` is written to `out_0.ifc` / `out_1.ifc`.

### Expected

```
group 0: 1,2,3,4,5,6,7,10,11,12,17
group 1: 1,2,3,4,5,6,7,13,14,15,17
```

## Root cause

`collectDeps` (and `collectDepsAll`) mark an id visited **before** discovering whether it resolves:

```ts
const id = stack.pop()!;
if (visited.has(id)) continue;
visited.add(id);              // <-- unconditional
const refs = index.getRefs(id);
if (!refs) continue;          // <-- only now do we learn no line defines it
```

`getRefs` returns `null` only for an id that was never passed to `LineIndex.set`, i.e. one with no line of its own — `set` records a zero-length ref list for defined lines with no references, so an empty result is distinguishable from a missing one. By then the id is already in `visited`, which *is* the group's `fileIds` set and is what `split()` returns as `ids`.

The ids get there because `extractRefs` scans a line's raw text for `#` + digits with no validation that the target exists.

## Impact

- `ids` is the natural input for building an id → group map. Sized by `max(ids)` it allocates for ids nothing can ever query; that bound is attacker/exporter-controlled through string content — a 9-digit number in a description field asks for a multi-GB array.
- Resolving such an id yields a group whose output file provably does not contain it, rather than "not found".
- `GroupData.totalIds` over-reports.

## Fix

```diff
     const id = stack.pop()!;
     if (visited.has(id)) continue;
-    visited.add(id);
     const refs = index.getRefs(id);
     if (!refs) continue;
+    visited.add(id);
```

in both `collectDeps` and `collectDepsAll`. Nothing downstream regresses: no line is ever emitted for these ids, so removing them changes only what is *reported*. It also shrinks the sets slightly.

## Related, not fixed by the above

`extractRefs` (`packages/fragments/src/Utils/ifc-parsing-utils.ts`) is not string-aware, so a `#N` in any quoted text is read as a reference. When `N` happens to name a **real** entity, that entity and its dependency subtree are pulled into the group — a text mention changes the output file's contents. Changing `'Wall B (see #99999)'` to `'Wall B (see #10)'` in the reproduction above adds `10` to group 1, which otherwise has no claim on it.

Whether the parser should skip single-quoted strings is a separate call — it touches every caller of `extractRefs`, not just the splitter.



