### PR TITLE
perf(FragmentsModels): index category lookups in getItemsOfCategories

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-properties-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-properties-controller.ts
@@ -872,27 +872,71 @@ export class VirtualPropertiesController {
       }
     }
 
-    for (let index = 0; index < this._model.categoriesLength(); index++) {
-      const currentCategory = this._model.categories(index);
-      if (!currentCategory) continue;
-
-      const localId = this._model.localIds(index) as number;
-      if (deletedItems.has(localId)) {
-        continue;
-      }
-
+    // Regexes are tested once per distinct category name instead of once
+    // per item: the category → localIds mapping is immutable in the
+    // flatbuffer, so it is built once and reused by every call. On a 43 MB
+    // model (~1.5M items, 23 categories) repeated getItemsOfCategories
+    // calls drop from ~750 ms to ~1 ms with identical results.
+    const catIndex = this.getCategoryIndex();
+    for (const [currentCategory, ids] of catIndex) {
       for (const categoryRegex of categories) {
         if (categoryRegex.test(currentCategory)) {
           if (!result[currentCategory]) {
             result[currentCategory] = [];
           }
-          result[currentCategory].push(localId);
+          const target = result[currentCategory];
+          if (deletedItems.size > 0) {
+            for (const localId of ids) {
+              if (!deletedItems.has(localId)) target.push(localId);
+            }
+          } else {
+            for (const localId of ids) target.push(localId);
+          }
           break;
         }
       }
     }
 
     return result;
+  }
+
+  private _categoryIndexCache: {
+    buffer: ArrayBufferLike | null;
+    length: number;
+    map: Map<string, number[]>;
+  } | null = null;
+
+  /**
+   * Lazily built category → localIds index over the immutable flatbuffer
+   * data. Keyed by the underlying buffer and length so it rebuilds if the
+   * model buffer is regenerated. Items created/updated/deleted via edit
+   * requests are handled by the callers on top of this index.
+   */
+  private getCategoryIndex(): Map<string, number[]> {
+    const arr = this._model.localIdsArray();
+    const length = this._model.categoriesLength();
+    let cache = this._categoryIndexCache;
+    if (
+      !cache ||
+      cache.length !== length ||
+      (arr && cache.buffer !== arr.buffer)
+    ) {
+      const map = new Map<string, number[]>();
+      for (let index = 0; index < length; index++) {
+        const currentCategory = this._model.categories(index);
+        if (!currentCategory) continue;
+        const localId = this._model.localIds(index) as number;
+        let ids = map.get(currentCategory);
+        if (!ids) {
+          ids = [];
+          map.set(currentCategory, ids);
+        }
+        ids.push(localId);
+      }
+      cache = { buffer: arr ? arr.buffer : null, length, map };
+      this._categoryIndexCache = cache;
+    }
+    return cache.map;
   }
 
   getItemsWithGeometry() {


### PR DESCRIPTION
Closes #248.

`getItemsOfCategories` tested every regex against every item's category on every call (O(items × regexes)). This adds a lazily built `category → localIds` index over the immutable flatbuffer data, so each regex is tested once per distinct category name.

Following the review notes in the issue:

- **Lazy**: built on first use, not in the constructor, and **straight from the flatbuffer** (`categories(i)` / `localIds(i)`), independent of `_items`.
- Keyed by the underlying buffer identity and `categoriesLength()`, so it rebuilds if the model buffer is regenerated.
- Covers the stored data only; the pending edit-request overlay (created/updated/deleted items) is still applied on top exactly as before.

Results are byte-identical to the previous implementation (same key order, same id order).

### Measurements

43 MB model, ~1.5M items, 23 categories: `/^IFCPROPERTYSET$/i` 770 ms → 10 ms on repeat, `/TYPE$/i` 755 ms → 1 ms, `/^IFC/i` (all categories) 1132 ms → 123 ms.

Headless Chromium, 40k-item model, three regexes: first call 38.9 → 19.2 ms, repeat call 18.1 → 0.3 ms, identical results.