### PR TITLE
perf(FragmentsModels): index pending edit requests by localId for property reads

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/virtual-model/edit-request-index.test.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/edit-request-index.test.ts
@@ -1,0 +1,251 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import pako from "pako";
+import { describe, expect, test } from "vitest";
+import { EditRequestIndex } from "./edit-request-index";
+import { VirtualFragmentsModel } from "./virtual-fragments-model";
+import { EditRequest, EditRequestType } from "../../../Utils";
+
+const fixture = path.resolve(
+  import.meta.dirname,
+  "../../../../../..",
+  "resources/frags/small_test.frag",
+);
+
+function loadModel() {
+  const data = pako.inflate(new Uint8Array(readFileSync(fixture)));
+  const model = new VirtualFragmentsModel(
+    "edit-request-index-test",
+    data as any,
+    undefined as any,
+  );
+  model.setupData();
+  return model;
+}
+
+// Reference implementations of the scans the index replaces
+function scanLatest(
+  requests: EditRequest[],
+  localId: number,
+  types: EditRequestType[],
+) {
+  for (let i = requests.length - 1; i >= 0; i--) {
+    const request = requests[i] as EditRequest & { localId?: number };
+    if (types.includes(request.type) && request.localId === localId) {
+      return request;
+    }
+  }
+  return undefined;
+}
+
+function scanDeleted(requests: EditRequest[]) {
+  const deleted = new Set<number>();
+  for (const request of requests) {
+    if (request.type === EditRequestType.DELETE_ITEM) {
+      deleted.add(request.localId as number);
+    }
+  }
+  return deleted;
+}
+
+const item = (name: string, category = "IFCWALL") => ({
+  category,
+  data: { Name: { value: name, type: "IfcLabel" } },
+});
+
+describe("EditRequestIndex", () => {
+  test("push, latest, first and deletedItems follow the request order", () => {
+    const index = new EditRequestIndex();
+    const create: EditRequest = {
+      type: EditRequestType.CREATE_ITEM,
+      localId: 7,
+      data: item("a"),
+    };
+    const update: EditRequest = {
+      type: EditRequestType.UPDATE_ITEM,
+      localId: 7,
+      data: item("b"),
+    };
+    const remove: EditRequest = {
+      type: EditRequestType.DELETE_ITEM,
+      localId: 7,
+    };
+    index.push(create);
+    index.push(update);
+
+    expect(
+      index.latest(7, EditRequestType.CREATE_ITEM, EditRequestType.UPDATE_ITEM),
+    ).toBe(update);
+    expect(index.first(7, EditRequestType.CREATE_ITEM)).toBe(create);
+    expect(index.latest(7, EditRequestType.CREATE_RELATION)).toBeUndefined();
+    expect(index.latest(8, EditRequestType.CREATE_ITEM)).toBeUndefined();
+    expect(index.deletedItems.has(7)).toBe(false);
+
+    index.push(remove);
+    expect(index.deletedItems.has(7)).toBe(true);
+
+    index.pop(remove);
+    expect(index.deletedItems.has(7)).toBe(false);
+    index.pop(update);
+    expect(
+      index.latest(7, EditRequestType.CREATE_ITEM, EditRequestType.UPDATE_ITEM),
+    ).toBe(create);
+    index.pop(create);
+    expect(index.latest(7, EditRequestType.CREATE_ITEM)).toBeUndefined();
+  });
+
+  test("a deleted item stays deleted until every DELETE_ITEM is popped", () => {
+    const index = new EditRequestIndex();
+    const first: EditRequest = {
+      type: EditRequestType.DELETE_ITEM,
+      localId: 3,
+    };
+    const second: EditRequest = {
+      type: EditRequestType.DELETE_ITEM,
+      localId: 3,
+    };
+    index.push(first);
+    index.push(second);
+    index.pop(second);
+    expect(index.deletedItems.has(3)).toBe(true);
+    index.pop(first);
+    expect(index.deletedItems.has(3)).toBe(false);
+  });
+
+  test("index requests are ignored and sync rebuilds a replaced array", () => {
+    const index = new EditRequestIndex();
+    const requests: EditRequest[] = [
+      {
+        type: EditRequestType.CREATE_INDEX,
+        data: { name: "idx", keys: [], values: [] } as any,
+      },
+      { type: EditRequestType.DELETE_ITEM, localId: 1 },
+    ];
+    index.sync(requests);
+    expect(index.deletedItems.has(1)).toBe(true);
+
+    // Same array, same length: no rebuild needed
+    index.sync(requests);
+    expect(index.deletedItems.has(1)).toBe(true);
+
+    // Length drift (external mutation) is picked up
+    requests.push({ type: EditRequestType.DELETE_ITEM, localId: 2 });
+    index.sync(requests);
+    expect(index.deletedItems.has(2)).toBe(true);
+
+    // A replaced array is rebuilt from scratch
+    index.sync([]);
+    expect(index.deletedItems.size).toBe(0);
+  });
+});
+
+describe("VirtualFragmentsModel property reads through the request index", () => {
+  test("created, updated, related and deleted items resolve like the full scans", () => {
+    const model = loadModel();
+    const [existing, other] = model.getLocalIds();
+    const originalName = model.getItemAttributes(existing)?.Name?.value;
+    const [existingCategory] = model.getItemsCategories([existing]);
+
+    const { ids } = model.edit([
+      { type: EditRequestType.CREATE_ITEM, data: item("New wall") },
+    ]);
+    const created = ids[0] as number;
+
+    expect(model.getItemAttributes(created)).toEqual(item("New wall").data);
+    expect(model.getItemsCategories([created])).toEqual(["IFCWALL"]);
+
+    model.edit([
+      {
+        type: EditRequestType.UPDATE_ITEM,
+        localId: existing,
+        data: item("Renamed", existingCategory!),
+      },
+      {
+        type: EditRequestType.CREATE_RELATION,
+        localId: created,
+        data: { data: { IsDefinedBy: [existing, other] } },
+      },
+      { type: EditRequestType.DELETE_ITEM, localId: other },
+    ]);
+
+    expect(model.getItemAttributes(existing)?.Name?.value).toBe("Renamed");
+    expect(model.getItemRelations(created)).toEqual({
+      IsDefinedBy: [existing, other],
+    });
+    expect(model.getItemsData([other], { attributesDefault: true })).toEqual([
+      {},
+    ]);
+    expect(
+      model.getItemsData([created], {
+        attributesDefault: true,
+        relations: { IsDefinedBy: { attributes: true, relations: false } },
+      })[0].IsDefinedBy,
+    ).toHaveLength(1); // the deleted relation target is skipped
+
+    // Same answers as scanning the whole requests list
+    const attrTypes = [
+      EditRequestType.CREATE_ITEM,
+      EditRequestType.UPDATE_ITEM,
+    ];
+    for (const id of [existing, other, created]) {
+      expect(model.requestIndex.latest(id, ...attrTypes)).toBe(
+        scanLatest(model.requests, id, attrTypes),
+      );
+    }
+    expect(model.requestIndex.deletedItems).toEqual(
+      scanDeleted(model.requests),
+    );
+
+    // Undo / redo / reset keep the index in step with the history
+    model.undo();
+    expect(model.requestIndex.deletedItems.size).toBe(0);
+    expect(model.getItemRelations(created)).toEqual({
+      IsDefinedBy: [existing, other],
+    });
+    model.redo();
+    expect(model.requestIndex.deletedItems.has(other)).toBe(true);
+
+    model.reset();
+    expect(model.requestIndex.deletedItems.size).toBe(0);
+    expect(model.getItemAttributes(created)).toBeNull();
+    expect(model.getItemAttributes(existing)?.Name?.value).toBe(originalName);
+  });
+
+  test("restoring, selecting and externally mutating the history rebuilds the index", () => {
+    const model = loadModel();
+    const [existing] = model.getLocalIds();
+    const [existingCategory] = model.getItemsCategories([existing]);
+
+    model.edit([
+      {
+        type: EditRequestType.UPDATE_ITEM,
+        localId: existing,
+        data: item("First", existingCategory!),
+      },
+    ]);
+    model.edit([
+      {
+        type: EditRequestType.UPDATE_ITEM,
+        localId: existing,
+        data: item("Second", existingCategory!),
+      },
+    ]);
+    const saved = model.getRequests().requests.slice();
+
+    model.reset();
+    expect(model.getItemAttributes(existing)?.Name?.value).not.toBe("Second");
+
+    model.setRequests({ requests: saved });
+    expect(model.getItemAttributes(existing)?.Name?.value).toBe("Second");
+
+    model.selectRequest(0);
+    expect(model.getItemAttributes(existing)?.Name?.value).toBe("First");
+
+    model.requests.push({
+      type: EditRequestType.UPDATE_ITEM,
+      localId: existing,
+      data: item("Third", existingCategory!),
+    });
+    expect(model.getItemAttributes(existing)?.Name?.value).toBe("Third");
+  });
+});

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/edit-request-index.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/edit-request-index.ts
@@ -1,0 +1,157 @@
+import { EditRequest, EditRequestType, isIndexRequest } from "../../../Utils";
+
+type RequestOfType<T extends EditRequestType> = Extract<
+  EditRequest,
+  { type: T }
+>;
+
+type LocalIdRequest = EditRequest & { localId?: number | string };
+
+/**
+ * Incremental lookup structures over the pending edit requests of a
+ * VirtualFragmentsModel.
+ *
+ * Property reads used to scan the whole `requests` array once per item, so a
+ * bulk read of N items with E pending requests cost O(N × E). This index keeps
+ * the requests grouped by the localId they target (in push order) plus the
+ * set of deleted items, so each per-item lookup is O(k) in the number of
+ * requests for that item.
+ *
+ * The owner keeps it in sync on push / undo / redo; any operation that
+ * replaces the requests array (reset, history selection, restoring saved
+ * requests) rebuilds it. `sync()` is the safety net for the tracked array
+ * being swapped or mutated behind the index's back.
+ */
+export class EditRequestIndex {
+  /** Local ids with a pending DELETE_ITEM request. */
+  readonly deletedItems = new Set<number>();
+
+  private _byLocalId = new Map<number | string, EditRequest[]>();
+  private _deleteCounts = new Map<number, number>();
+  private _source: EditRequest[] | null = null;
+  private _size = 0;
+
+  /**
+   * Makes sure the index reflects `requests`. Cheap when the tracked array is
+   * unchanged; rebuilds when it was replaced or its length drifted.
+   */
+  sync(requests: EditRequest[]) {
+    if (this._source === requests && this._size === requests.length) {
+      return;
+    }
+    this.rebuild(requests);
+  }
+
+  rebuild(requests: EditRequest[]) {
+    this._byLocalId.clear();
+    this._deleteCounts.clear();
+    this.deletedItems.clear();
+    this._source = requests;
+    this._size = 0;
+    for (const request of requests) {
+      this.push(request);
+    }
+  }
+
+  /** Registers a request that was just appended to the tracked array. */
+  push(request: EditRequest) {
+    this._size++;
+    const localId = this.localIdOf(request);
+    if (localId === undefined) {
+      return;
+    }
+    let list = this._byLocalId.get(localId);
+    if (!list) {
+      list = [];
+      this._byLocalId.set(localId, list);
+    }
+    list.push(request);
+    if (
+      request.type === EditRequestType.DELETE_ITEM &&
+      typeof localId === "number"
+    ) {
+      this._deleteCounts.set(
+        localId,
+        (this._deleteCounts.get(localId) ?? 0) + 1,
+      );
+      this.deletedItems.add(localId);
+    }
+  }
+
+  /** Unregisters a request that was just removed from the tracked array. */
+  pop(request: EditRequest) {
+    this._size--;
+    const localId = this.localIdOf(request);
+    if (localId === undefined) {
+      return;
+    }
+    const list = this._byLocalId.get(localId);
+    if (list) {
+      // Undo removes the newest request, so this is normally the last entry
+      for (let i = list.length - 1; i >= 0; i--) {
+        if (list[i] === request) {
+          list.splice(i, 1);
+          break;
+        }
+      }
+      if (list.length === 0) {
+        this._byLocalId.delete(localId);
+      }
+    }
+    if (
+      request.type === EditRequestType.DELETE_ITEM &&
+      typeof localId === "number"
+    ) {
+      const count = (this._deleteCounts.get(localId) ?? 1) - 1;
+      if (count > 0) {
+        this._deleteCounts.set(localId, count);
+      } else {
+        this._deleteCounts.delete(localId);
+        this.deletedItems.delete(localId);
+      }
+    }
+  }
+
+  /** Newest pending request of one of the given types targeting `localId`. */
+  latest<T extends EditRequestType>(
+    localId: number | string,
+    ...types: T[]
+  ): RequestOfType<T> | undefined {
+    const list = this._byLocalId.get(localId);
+    if (!list) {
+      return undefined;
+    }
+    for (let i = list.length - 1; i >= 0; i--) {
+      const request = list[i];
+      if (types.includes(request.type as T)) {
+        return request as RequestOfType<T>;
+      }
+    }
+    return undefined;
+  }
+
+  /** Oldest pending request of one of the given types targeting `localId`. */
+  first<T extends EditRequestType>(
+    localId: number | string,
+    ...types: T[]
+  ): RequestOfType<T> | undefined {
+    const list = this._byLocalId.get(localId);
+    if (!list) {
+      return undefined;
+    }
+    for (const request of list) {
+      if (types.includes(request.type as T)) {
+        return request as RequestOfType<T>;
+      }
+    }
+    return undefined;
+  }
+
+  private localIdOf(request: EditRequest) {
+    // Index requests are name-keyed and never target an item
+    if (isIndexRequest(request)) {
+      return undefined;
+    }
+    return (request as LocalIdRequest).localId;
+  }
+}

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-properties-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-properties-controller.ts
@@ -316,13 +316,12 @@ export class VirtualPropertiesController {
       let category = this._items.get(localId)?.category ?? null;
       if (category === null) {
         // If the item was created, return the created category
-        for (let i = this._virtualModel.requests.length - 1; i >= 0; i--) {
-          const request = this._virtualModel.requests[i];
-          if (request.type === EditRequestType.CREATE_ITEM) {
-            if (request.localId === localId) {
-              category = request.data.category;
-            }
-          }
+        const created = this._virtualModel.requestIndex.first(
+          localId,
+          EditRequestType.CREATE_ITEM,
+        );
+        if (created) {
+          category = created.data.category;
         }
       }
       result.push(category);
@@ -562,26 +561,24 @@ export class VirtualPropertiesController {
     if (localId === null) {
       return null;
     }
+    // Newest pending edit of this item's attributes, if any
+    const edited = this._virtualModel.requestIndex.latest(
+      localId,
+      EditRequestType.CREATE_ITEM,
+      // DO NOT remove this or editing created items break
+      // if you have problems with this, contact Antonio
+      EditRequestType.UPDATE_ITEM,
+    );
     const index = this.indexOfLocalId(localId);
     if (index === undefined || index === -1) {
       // If the item was created, return the created data
-      const data: Record<string, { value: any; type?: string }> = {};
-      for (let i = this._virtualModel.requests.length - 1; i >= 0; i--) {
-        const request = this._virtualModel.requests[i];
-        if (
-          request.type === EditRequestType.CREATE_ITEM ||
-          // DO NOT remove this or editing created items break
-          // if you have problems with this, contact Antonio
-          request.type === EditRequestType.UPDATE_ITEM
-        ) {
-          if (request.localId === localId) {
-            for (const name in request.data.data) {
-              const found = request.data.data[name];
-              data[name] = { value: found.value, type: found.type };
-            }
-            return data;
-          }
+      if (edited) {
+        const data: Record<string, { value: any; type?: string }> = {};
+        for (const name in edited.data.data) {
+          const found = edited.data.data[name];
+          data[name] = { value: found.value, type: found.type };
         }
+        return data;
       }
 
       // No previous id found and no new item, return null
@@ -594,21 +591,12 @@ export class VirtualPropertiesController {
     const data: Record<string, { value: any; type?: string }> = {};
 
     // If edited, return edited data
-    // We traverse it backwards to get the latest edited data
-    for (let i = this._virtualModel.requests.length - 1; i >= 0; i--) {
-      const request = this._virtualModel.requests[i];
-      if (
-        request.type === EditRequestType.UPDATE_ITEM ||
-        request.type === EditRequestType.CREATE_ITEM
-      ) {
-        if (request.localId === localId) {
-          for (const name in request.data.data) {
-            const found = request.data.data[name];
-            data[name] = { value: found.value, type: found.type };
-          }
-          return data;
-        }
+    if (edited) {
+      for (const name in edited.data.data) {
+        const found = edited.data.data[name];
+        data[name] = { value: found.value, type: found.type };
       }
+      return data;
     }
 
     for (let j = 0; j < buffer.dataLength(); j++) {
@@ -671,14 +659,10 @@ export class VirtualPropertiesController {
     const localId =
       typeof id === "number" ? id : this._guidToLocalIdMap.get(id) ?? null;
 
-    const deletedItems = new Set<number>();
-    for (const request of this._virtualModel.requests) {
-      if (request.type === EditRequestType.DELETE_ITEM) {
-        deletedItems.add(request.localId as number);
-      }
-    }
-
-    if (localId === null || deletedItems.has(localId)) {
+    if (
+      localId === null ||
+      this._virtualModel.requestIndex.deletedItems.has(localId)
+    ) {
       return {};
     }
 
@@ -717,6 +701,7 @@ export class VirtualPropertiesController {
 
     if (relations) {
       const itemRels = this.getItemRelations(id);
+      const { deletedItems } = this._virtualModel.requestIndex;
       for (const [key, localIds] of Object.entries(itemRels ?? {})) {
         for (const localId of localIds) {
           if (deletedItems.has(localId)) {
@@ -779,21 +764,18 @@ export class VirtualPropertiesController {
     const isLocalId = typeof id === "number";
     const localId = isLocalId ? id : this.getLocalIdsByGuids([id])[0];
 
-    // If a relation was created or updated and not saved yet, return the newest relation
-    for (let i = this._virtualModel.requests.length - 1; i >= 0; i--) {
-      const request = this._virtualModel.requests[i];
-      if (
-        request.type === EditRequestType.UPDATE_RELATION ||
-        request.type === EditRequestType.CREATE_RELATION
-      ) {
-        if (request.localId === localId) {
-          return request.data.data;
-        }
-      }
-    }
-
     if (localId === null) {
       return null;
+    }
+
+    // If a relation was created or updated and not saved yet, return the newest relation
+    const edited = this._virtualModel.requestIndex.latest(
+      localId,
+      EditRequestType.UPDATE_RELATION,
+      EditRequestType.CREATE_RELATION,
+    );
+    if (edited) {
+      return edited.data.data;
     }
     const relations = this._relations.get(localId) ?? {};
     const index = this.indexOfRelationsItem(localId);
@@ -1063,43 +1045,42 @@ export class VirtualPropertiesController {
       }
     } else {
       for (const localId of missingItemsToIterate) {
-        // If the item was created, return the created data
-        for (let i = this._virtualModel.requests.length - 1; i >= 0; i--) {
-          const request = this._virtualModel.requests[i];
-          if (request.type === EditRequestType.CREATE_ITEM) {
-            if (request.localId !== localId) continue;
-            // Collect item data
-            const data: Record<string, { value: any; type?: string }> = {};
-            for (const name in request.data.data) {
-              const found = request.data.data[name];
-              data[name] = { value: found.value, type: found.type };
-            }
+        // If the item was created, check the created data
+        const created = this._virtualModel.requestIndex.latest(
+          localId,
+          EditRequestType.CREATE_ITEM,
+        );
+        if (!created) continue;
+        // Collect item data
+        const data: Record<string, { value: any; type?: string }> = {};
+        for (const name in created.data.data) {
+          const found = created.data.data[name];
+          data[name] = { value: found.value, type: found.type };
+        }
 
-            // Check if it passes
-            let itemPasses = false;
-            for (const [
-              attrName,
-              { value: val, type: typeValue },
-            ] of Object.entries(data)) {
-              const pass = this.checkAttribute(
-                {
-                  name: attrName,
-                  value: val,
-                  type: typeValue,
-                },
-                { name, value, type },
-              );
+        // Check if it passes
+        let itemPasses = false;
+        for (const [
+          attrName,
+          { value: val, type: typeValue },
+        ] of Object.entries(data)) {
+          const pass = this.checkAttribute(
+            {
+              name: attrName,
+              value: val,
+              type: typeValue,
+            },
+            { name, value, type },
+          );
 
-              if (pass) {
-                itemPasses = true;
-                break;
-              }
-            }
-
-            if (negate ? !itemPasses : itemPasses) {
-              res.push(localId);
-            }
+          if (pass) {
+            itemPasses = true;
+            break;
           }
+        }
+
+        if (negate ? !itemPasses : itemPasses) {
+          res.push(localId);
         }
       }
     }

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-fragments-model.ts
@@ -55,6 +55,7 @@ import {
   VisibilityHelper,
 } from "./virtual-helpers";
 import { TileData } from "./virtual-meshes";
+import { EditRequestIndex } from "./edit-request-index";
 
 export class VirtualFragmentsModel {
   data: Model;
@@ -68,6 +69,8 @@ export class VirtualFragmentsModel {
   indexes: VirtualIndexesController;
 
   requests: EditRequest[] = [];
+
+  private _requestIndex = new EditRequestIndex();
 
   private _raycastHelper = new RaycastHelper();
   private _coordinatesHelper = new CoordinatesHelper();
@@ -586,11 +589,21 @@ export class VirtualFragmentsModel {
     return this.tiles.tilesUpdated;
   }
 
+  /**
+   * Per-localId lookup over the pending requests, used by the property reads
+   * instead of scanning the whole requests list per item.
+   */
+  get requestIndex() {
+    this._requestIndex.sync(this.requests);
+    return this._requestIndex;
+  }
+
   edit(requests: EditRequest[], raw = true) {
     const ids = EditUtils.solveIds(requests, this._nextId);
     this._nextId += ids.length;
     for (const request of requests) {
       this.requests.push(request);
+      this._requestIndex.push(request);
     }
     const { model, items } = EditUtils.edit(this.data, this.requests, {
       raw,
@@ -607,14 +620,17 @@ export class VirtualFragmentsModel {
   reset() {
     this.requests = [];
     this._requestsForRedo = [];
+    this._requestIndex.rebuild(this.requests);
     this._nextId = this.getMaxLocalId();
   }
 
   save(raw = true) {
-    this.requests.push({
+    const request: EditRequest = {
       type: EditRequestType.UPDATE_MAX_LOCAL_ID,
       localId: this._nextId,
-    });
+    };
+    this.requests.push(request);
+    this._requestIndex.push(request);
     const { model } = EditUtils.edit(this.data, this.requests, {
       raw,
       delta: false,
@@ -630,6 +646,7 @@ export class VirtualFragmentsModel {
     if (!lastRequest) {
       return;
     }
+    this._requestIndex.pop(lastRequest);
     this._requestsForRedo.unshift(lastRequest);
   }
 
@@ -642,6 +659,7 @@ export class VirtualFragmentsModel {
       return;
     }
     this.requests.push(lastUndoneRequest);
+    this._requestIndex.push(lastUndoneRequest);
   }
 
   getRequests() {
@@ -657,6 +675,7 @@ export class VirtualFragmentsModel {
   }) {
     if (data.requests) {
       this.requests = data.requests;
+      this._requestIndex.rebuild(this.requests);
     }
     if (data.undoneRequests) {
       this._requestsForRedo = data.undoneRequests;
@@ -682,6 +701,7 @@ export class VirtualFragmentsModel {
         this._requestsForRedo.push(allRequests[i]);
       }
     }
+    this._requestIndex.rebuild(this.requests);
   }
 
   getMaterialsIds() {


### PR DESCRIPTION
Part 1 of #247 (per-item scans of the requests list), scoped as agreed in the issue — the `edit()` cumulative-history rebuild (part 2) is left for the incremental edit mode.

`VirtualPropertiesController` scanned the whole `requests` array once per item read (`getItemAttributes`, `getItemRelations`, `getItemsCategories`, the created-item branch of `getItemsByAttribute`) and rebuilt the `deletedItems` Set from the full list per item in `getItemData`, so a bulk read of N items with E pending requests cost O(N × E).

This adds `EditRequestIndex`: requests grouped by the localId they target (in push order) plus a persistent `deletedItems` Set. `VirtualFragmentsModel` keeps it in step on `edit`/`save` (push), `undo` (pop) and `redo` (push), and rebuilds it when the requests array is replaced (`reset`, `setRequests`, `selectRequest`). The index also re-syncs itself if the tracked array is swapped or grows behind its back. The six per-item scans become O(k) lookups in the number of requests for that item; per-call enumerations (`getCategories`, `getItemsOfCategories`, the itemIds-less branch of `getItemsByAttribute`) are unchanged.

Tests (`edit-request-index.test.ts`, vitest) cover the index bookkeeping and, on `resources/frags/small_test.frag`, equivalence with the previous full scans across create/update/relate/delete, undo/redo/reset, restored histories and external mutation.

### Measurements

Node, 255k-item model, `getItemsData` over 50k items with `attributesDefault`:

| pending requests | 3.4.7 | this PR |
|---|---|---|
| 2 000 | 1 722 ms | 368 ms |
| 10 000 | 6 740 ms | 350 ms |

`getItemAttributes` × 50k: 579 → 97 ms (2k requests), 2 389 → 102 ms (10k requests).

Headless Chromium (worker path), 40k-item model, 2 006 pending requests, `getItemsData` over 20k items: 561 → 270 ms.