### PR TITLE
perf(FragmentsModels): skip view refresh when the view is unchanged and coalesce forced updates

### DIFF
--- a/packages/fragments/src/FragmentsModels/index.ts
+++ b/packages/fragments/src/FragmentsModels/index.ts
@@ -343,6 +343,10 @@ export class FragmentsModels {
    */
   async dispose() {
     this._isDisposed = true;
+    if (this._autoRedrawInterval) {
+      clearTimeout(this._autoRedrawInterval);
+      this._autoRedrawInterval = null;
+    }
     const models = Array.from(this.models.list.values());
     const promises = [];
     for (const model of models) {
@@ -391,15 +395,23 @@ export class FragmentsModels {
       return;
     }
     const now = performance.now();
-    if (now - this._lastUpdate < this.settings.maxUpdateRate) {
+    if (!force && now - this._lastUpdate < this.settings.maxUpdateRate) {
+      // Keep the poll alive: view changes are detected by these
+      // periodic checks, so a throttled call must still leave a
+      // scheduled one behind. Cheap — no worker traffic happens
+      // until a view actually changes.
+      this.scheduleNextUpdate();
       return;
     }
     this._lastUpdate = now;
 
-    // Update the virtual view for all models
+    // Update the virtual view for all models. Unforced refreshes are
+    // skipped per model when its view is unchanged (no RPC at all);
+    // forced ones always dispatch because their FINISH acts as the
+    // completion fence for forceUpdateFinish below.
     const modelUpdates: Promise<void>[] = [];
     for (const model of this.models.list.values()) {
-      modelUpdates.push(model._refreshView());
+      modelUpdates.push(model._refreshView(force));
     }
     await Promise.all(modelUpdates);
 
@@ -411,6 +423,28 @@ export class FragmentsModels {
     } else {
       this.models.update();
     }
+    this.scheduleNextUpdate();
+  }
+
+  /**
+   * (Re)schedules the next automatic update. The view-change gating
+   * means an idle scene produces no worker messages and thus no
+   * FINISH-driven update events, so the loop sustains itself with
+   * this timer instead. Skipped when disposed or no models exist —
+   * the next model load (or any mesh update event) restarts it.
+   */
+  private scheduleNextUpdate() {
+    if (this._isDisposed || this.models.list.size === 0) {
+      return;
+    }
+    if (this._autoRedrawInterval) {
+      clearTimeout(this._autoRedrawInterval);
+    }
+    const offset = this.settings.maxUpdateRate + 1;
+    this._autoRedrawInterval = setTimeout(() => {
+      this._autoRedrawInterval = null;
+      this.update();
+    }, offset);
   }
 
   private async manageRequest(message: any): Promise<void> {

--- a/packages/fragments/src/FragmentsModels/index.ts
+++ b/packages/fragments/src/FragmentsModels/index.ts
@@ -172,6 +172,7 @@ export class FragmentsModels {
   private _isDisposed = false;
   private _autoRedrawInterval: any = null;
   private _lastUpdate = 0;
+  private _pendingForcedUpdate: Promise<void> | null = null;
 
   /**
    * Creates a new FragmentsModels instance.
@@ -395,15 +396,44 @@ export class FragmentsModels {
       return;
     }
     const now = performance.now();
-    if (!force && now - this._lastUpdate < this.settings.maxUpdateRate) {
-      // Keep the poll alive: view changes are detected by these
-      // periodic checks, so a throttled call must still leave a
-      // scheduled one behind. Cheap — no worker traffic happens
-      // until a view actually changes.
-      this.scheduleNextUpdate();
+    const elapsed = now - this._lastUpdate;
+    if (elapsed < this.settings.maxUpdateRate) {
+      if (!force) {
+        // Keep the poll alive: view changes are detected by these
+        // periodic checks, so a throttled call must still leave a
+        // scheduled one behind. Cheap — no worker traffic happens
+        // until a view actually changes.
+        this.scheduleNextUpdate();
+        return;
+      }
+      // Forced updates must not be dropped (callers await them as a
+      // fence), but they must not bypass the rate limit either: camera
+      // controls emit "rest" — and the components layer forces an
+      // update on it — on nearly every frame of a programmatic orbit,
+      // and each forced refresh is a full re-cull plus an unbounded
+      // drain on the main thread. Coalesce every forced call inside
+      // the window into one trailing forced update; awaiting callers
+      // are released when that one has settled, which covers all the
+      // RPCs they could have been waiting for.
+      if (!this._pendingForcedUpdate) {
+        const delay = this.settings.maxUpdateRate - elapsed + 1;
+        this._pendingForcedUpdate = new Promise<void>((resolve) => {
+          setTimeout(() => {
+            this._pendingForcedUpdate = null;
+            this.performUpdate(true).then(resolve, () => resolve());
+          }, delay);
+        });
+      }
+      return this._pendingForcedUpdate;
+    }
+    return this.performUpdate(force);
+  }
+
+  private async performUpdate(force: boolean) {
+    if (this._isDisposed) {
       return;
     }
-    this._lastUpdate = now;
+    this._lastUpdate = performance.now();
 
     // Update the virtual view for all models. Unforced refreshes are
     // skipped per model when its view is unchanged (no RPC at all);

--- a/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/fragments-model.ts
@@ -1111,10 +1111,19 @@ export class FragmentsModel implements IFragmentsModel<true> {
   /**
    * Internal method to refresh the view of the model. You shouldn't call this directly. Instead, use {@link FragmentsModels.update}.
    */
-  async _refreshView() {
+  async _refreshView(force = false) {
     if (this.frozen) return;
-    this._isProcessing = true;
-    const mainPromise = this._viewManager.refreshView(this, this._meshManager);
+    // Only mark the model busy when a REFRESH_VIEW was actually
+    // dispatched — a skipped (unchanged-view) refresh produces no
+    // FINISH, so setting the flag would leave `isBusy` stuck. The
+    // flag flips before the worker can emit the resulting FINISH
+    // (mesh batches flush at least one macrotask later), so there is
+    // no window where the FINISH could be consumed first.
+    const mainPromise = this._viewManager
+      .refreshView(this, this._meshManager, force)
+      .then((sent) => {
+        if (sent) this._isProcessing = true;
+      });
     const deltaPromise = this._editor._update(this.modelId);
     await Promise.all([mainPromise, deltaPromise]);
   }

--- a/packages/fragments/src/FragmentsModels/src/model/view-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/view-manager.ts
@@ -14,6 +14,15 @@ export class ViewManager {
   private readonly _tempVec = new THREE.Vector3();
   private readonly _tempFrustum = new THREE.Frustum();
 
+  /**
+   * Numeric fingerprint of the last view dispatched to the worker.
+   * `refreshView` skips the REFRESH_VIEW RPC when the view is
+   * identical to the previous one (unless forced), so an idle camera
+   * produces zero worker traffic instead of a full re-cull of every
+   * sample on every update tick. See {@link refreshView}.
+   */
+  private _lastViewSignature: number[] | null = null;
+
   private _updateCameraPositionEvent: (vector: THREE.Vector3) => void =
     () => {};
 
@@ -24,11 +33,31 @@ export class ViewManager {
 
   private _updateOrthoSizeEvent: () => number | void = () => {};
 
-  async refreshView(model: FragmentsModel, meshes: MeshManager) {
-    const fov = this.setup(meshes, model);
+  /**
+   * Sends the current view to the worker so it can re-evaluate culling
+   * and LOD. Returns `true` if a REFRESH_VIEW was actually dispatched.
+   *
+   * When `force` is false and the view (camera frustum + position in
+   * model space, clipping planes, viewport size, quality, model
+   * placement) is unchanged since the last dispatch, the RPC is
+   * skipped entirely and `false` is returned. Visibility, highlight,
+   * LOD-mode and edit changes don't need a view resend — the worker
+   * restarts its own tile pass for those. Forced sends always go
+   * through because `FragmentsModels.update(true)` uses the resulting
+   * FINISH as a completion fence.
+   */
+  async refreshView(model: FragmentsModel, meshes: MeshManager, force = false) {
+    const fov = this.setup(model);
     const frustum = CameraUtils.transform(this._tempFrustum, this._tempMatrix);
     const request: any = this.newViewRequest(frustum, fov, model);
+    const signature = this.computeViewSignature(request.view, model);
+    if (!force && this.signatureEquals(signature)) {
+      return false;
+    }
+    this._lastViewSignature = signature;
+    meshes.requests.clean(model.modelId);
     await model.threads.fetch(request);
+    return true;
   }
 
   useCamera(camera: THREE.PerspectiveCamera | THREE.OrthographicCamera) {
@@ -55,13 +84,61 @@ export class ViewManager {
     return orthoSize;
   }
 
-  private setup(meshes: MeshManager, model: FragmentsModel) {
-    meshes.requests.clean(model.modelId);
+  private setup(model: FragmentsModel) {
     this._tempMatrix.copy(model.object.matrixWorld).invert();
     this._updateCameraPositionEvent(this._tempVec);
     this._updateCameraFrustumEvent(this._tempFrustum);
     const fov = this._updateFOVEvent();
     return fov;
+  }
+
+  /**
+   * Flattens everything view-relevant into a number list for cheap
+   * equality checks. `graphicThreshold` is deliberately excluded: it
+   * only budgets the worker's invisible-tile cache, so a change in it
+   * (e.g. the worker count changed) shouldn't force a full re-cull.
+   * `undefined` fields (fov on ortho cameras, ortho size on
+   * perspective ones) are encoded as NaN and compared with
+   * `Object.is` semantics below.
+   */
+  private computeViewSignature(view: any, model: FragmentsModel) {
+    const signature: number[] = [];
+    const frustum = view.cameraFrustum as THREE.Frustum;
+    for (const plane of frustum.planes) {
+      signature.push(plane.normal.x, plane.normal.y, plane.normal.z);
+      signature.push(plane.constant);
+    }
+    const position = view.cameraPosition as THREE.Vector3;
+    signature.push(position.x, position.y, position.z);
+    signature.push(view.fov ?? NaN);
+    signature.push(view.orthogonalDimension ?? NaN);
+    signature.push(view.viewSize);
+    signature.push(view.graphicQuality);
+    for (const plane of view.clippingPlanes as THREE.Plane[]) {
+      signature.push(plane.normal.x, plane.normal.y, plane.normal.z);
+      signature.push(plane.constant);
+    }
+    for (const element of model.object.matrixWorld.elements) {
+      signature.push(element);
+    }
+    return signature;
+  }
+
+  private signatureEquals(signature: number[]) {
+    const last = this._lastViewSignature;
+    if (!last || last.length !== signature.length) {
+      return false;
+    }
+    for (let i = 0; i < signature.length; i++) {
+      // NaN encodes "undefined" — treat NaN === NaN as equal.
+      if (
+        signature[i] !== last[i] &&
+        !(Number.isNaN(signature[i]) && Number.isNaN(last[i]))
+      ) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private newViewRequest(

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-tiles-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-tiles-controller.ts
@@ -209,8 +209,23 @@ export class VirtualTilesController {
   }
 
   setupView(view: any) {
+    const previous = this._virtualView;
     this._virtualView = view;
     VirtualMemoryController.setCapacity(view.meshThreshold);
+    if (previous && this.viewEquals(previous, view)) {
+      // Same view as before (typically a forced update used as a
+      // completion fence): adopt the new view object (it may carry a
+      // fresh graphicThreshold) but skip the full re-cull. If the
+      // previous pass already finished, emit a FINISH directly so
+      // main-side `forceUpdateFinish` fences settle; if a pass is
+      // still running, its natural FINISH will carry this RPC's seq
+      // because the stamp is read at emission time.
+      this.setupViewPlanes();
+      if (this.tilesUpdated) {
+        this.emitFinish();
+      }
+      return;
+    }
     this.restart();
     this.updateOrientationIfNeeded();
     this.updatePositionIfNeeded();
@@ -414,6 +429,11 @@ export class VirtualTilesController {
     if (!updateFinished) {
       return;
     }
+    this.emitFinish();
+    this.tilesUpdated = true;
+  }
+
+  private emitFinish() {
     this._meshConnection.process({
       tileRequestClass: TileRequestClass.FINISH,
       modelId: this._modelId,
@@ -426,7 +446,53 @@ export class VirtualTilesController {
       // waiters precisely, no buffer / poll required.
       seq: thread.lastSeenSeq,
     });
-    this.tilesUpdated = true;
+  }
+
+  /**
+   * Structural equality of two worker-side views, covering every field
+   * the culling/LOD pass reads. `graphicThreshold` is deliberately
+   * ignored — it only budgets the invisible-tile cache, so a change in
+   * it must not trigger a full re-cull (the new value still takes
+   * effect because the caller stores the incoming view first).
+   */
+  private viewEquals(a: any, b: any): boolean {
+    if (
+      a.fov !== b.fov ||
+      a.orthogonalDimension !== b.orthogonalDimension ||
+      a.viewSize !== b.viewSize ||
+      a.graphicQuality !== b.graphicQuality
+    ) {
+      return false;
+    }
+    if (!this.vectorEquals(a.cameraPosition, b.cameraPosition)) {
+      return false;
+    }
+    const aPlanes = a.cameraFrustum.planes;
+    const bPlanes = b.cameraFrustum.planes;
+    for (let i = 0; i < aPlanes.length; i++) {
+      if (!this.planeEquals(aPlanes[i], bPlanes[i])) {
+        return false;
+      }
+    }
+    const aClipping = a.clippingPlanes || [];
+    const bClipping = b.clippingPlanes || [];
+    if (aClipping.length !== bClipping.length) {
+      return false;
+    }
+    for (let i = 0; i < aClipping.length; i++) {
+      if (!this.planeEquals(aClipping[i], bClipping[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private planeEquals(a: THREE.Plane, b: THREE.Plane) {
+    return a.constant === b.constant && this.vectorEquals(a.normal, b.normal);
+  }
+
+  private vectorEquals(a: THREE.Vector3, b: THREE.Vector3) {
+    return a.x === b.x && a.y === b.y && a.z === b.z;
   }
 
   private updatePositionIfNeeded() {


### PR DESCRIPTION
Part of #279 (the idle re-cull loop and the forced-update handling; the per-worker cache budget and the ThreadUpdater fairness are separate).

Two commits, they belong together — the second is what makes the first safe under a real app's update pattern.

**1. Skip the refresh when the view has not changed.** `ViewManager` fingerprints the outgoing view (frustum planes, camera position in model space, clipping planes, viewport size, graphics quality, model placement) and skips the `REFRESH_VIEW` RPC when nothing changed. Worker-side `setupView()` compares the incoming view against the current one and skips the full re-cull when identical, emitting a FINISH directly when its pass is already complete, so `update(true)` fences still settle; an in-flight pass keeps running and its natural FINISH carries the new seq. `graphicThreshold` is deliberately excluded from both comparisons so a budget change cannot trigger a re-cull. Because an idle scene then produces no worker traffic — and therefore no FINISH to drive the next `update()` — `update()` reschedules itself with a light timer instead. `_isProcessing` is only set when a refresh was actually dispatched, so `isBusy` cannot stick on a skipped refresh.

**2. Coalesce forced updates instead of dropping them or letting them through.** Today `update(true)` inside `maxUpdateRate` returns early: the caller awaits a fence that never happened. Simply exempting forced calls from the throttle is worse in practice — `@thatopen/components` forces an update on every camera-controls `rest`, which fires on nearly every frame of a programmatic orbit, and each forced refresh is a full re-cull plus an unbounded `drainAll()` on the main thread (I measured −10 % orbit FPS and 3× the long-task time with that variant). Forced calls landing inside the window are now merged into a single trailing forced update, and every awaiting caller resolves when that one has settled — which covers all the RPCs they could have been waiting for. Fence semantics are unchanged.

## Measurements

Headless Chromium, Radeon 780M, 1920×1080, medians of 3 runs, measured against a baseline run interleaved with it (this box thermally throttles over a long chain, so a baseline from 40 minutes earlier is not comparable).

| | before | after |
|---|---|---|
| `REFRESH_VIEW` per 5 s idle, 1 model / 8 models | 15 / 112 | **0 / 0** |
| tile batches per 5 s idle, 8 models | 109 | **2** |
| settle after orbit, 1 model | 875 ms | **600 ms** |
| render CPU ms, 8 models, idle | 31.5 | **30.0** |
| FPS, 8 models, idle / orbit | 30.7 / 32.1 | **32.0 / 32.4** |
| long tasks per 5 s orbit, 8 models | 50 ms | **0 ms** |
| JS heap after load, 8 models | 441 MB | **378 MB** |

An older measurement of the same idle-loop fix on 13 models (headless, SwiftShader): 15 s idle went from 1 358 worker RPCs and 31.8 s of browser-process CPU to 0–31 RPCs and 11.0 s.

Screenshots of six fixed poses are pixel-identical. Visibility and highlight changes, camera moves, clipping-plane changes and `update(true)` fences verified against the current build.

The remaining piece of #279 — dividing the invisible-tile cache budget by the active worker count — is now #286. I first assumed it depended on this PR; re-measuring it against an interleaved baseline showed it is neutral on frame time on its own, so the two are independent and can go in either order.

---

Also from #279: #284 (ThreadUpdater fairness) and #286 (per-worker tile-cache budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rtNQqhSQRM2t6E98DESNE

---

**Scope note** (added 2026-09-07, after an independent test on an 11-model MEP scene reported on the forum): this PR stops the idle re-cull loop — there the worker messages in the idle state went 1383 → 826 per 5 s with no frustum-culling message left — but the renderer still draws the scene every frame. An app that wants zero idle work can additionally set `model.frozen = true` on all models when it goes idle and clear it on the next input; raycasting keeps working on frozen models.
