### PR TITLE
perf(FragmentsModels): rotate the per-tick starting model in ThreadUpdater

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-updater.ts
+++ b/packages/fragments/src/FragmentsModels/src/multithreading/thread-controllers/thread-updater.ts
@@ -56,17 +56,35 @@ export class ThreadUpdater {
     this.schedule(delay);
   };
 
+  // Offset into the model list where the next tick starts. Rotating the
+  // start point keeps one model with a long-running cull pass from
+  // eating the whole per-tick time budget every tick and starving the
+  // other models on this worker.
+  private _nextModelOffset = 0;
+
   private updateAllModels() {
     const start = performance.now();
     let isUpdated = true;
-    for (const [, model] of this._thread.list) {
+    const models = Array.from(this._thread.list.values());
+    const offset = this._nextModelOffset % models.length;
+    let processed = 0;
+    for (; processed < models.length; processed++) {
+      const model = models[(offset + processed) % models.length];
       const modelUpdated = model.update(start);
       isUpdated = isUpdated && modelUpdated;
       const end = performance.now();
       const timePassed = end - start;
       if (timePassed > this._updateThreshold) {
+        processed++;
         break;
       }
+    }
+    this._nextModelOffset = (offset + processed) % models.length;
+    // Models we didn't reach this tick may still have pending work, so
+    // don't let the loop back off to the idle delay based on a partial
+    // sweep.
+    if (processed < models.length) {
+      isUpdated = false;
     }
     return isUpdated;
   }


### PR DESCRIPTION
Part of #279 (the ThreadUpdater fairness point).

`updateAllModels()` always restarts iteration at the head of `thread.list` and `break`s once the 16 ms budget is spent, so with several models on one worker the first model in insertion order consumes the budget every tick and the ones after it are starved until its pass completes. Two changes:

- the tick resumes where the previous one stopped (a rotating start index over the same map order, so every model gets the head of the budget in turn);
- a sweep that stopped early no longer reports the thread as fully updated — models the tick never reached may still have pending work, and reporting `true` let that work sit idle for a whole `updateDelay`.

Self-contained, 19 lines, no API change.

## Measurements

On the 8-model scenes I have here (one big model plus seven small ones, so the big model dominates its own worker) this is neutral within noise: draw calls, screenshots and settle times are unchanged, tile batches per 5 s idle 115 → 102. The case it fixes is several *comparable* models sharing a worker — the worker pool caps at `hardwareConcurrency - 3`, so that is what happens as soon as a project has more models than cores. I am proposing it as a fairness/correctness fix rather than a measured speedup; happy to drop it if you'd rather see a scene where it moves a number.

---

Also from #279: #283 (idle re-cull loop and forced updates), which is the part that actually moves the numbers, and #286 (per-worker tile-cache budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rtNQqhSQRM2t6E98DESNE

---

**Context** (added 2026-09-07): in an independent idle measurement on an 11-model scene with #283 applied, the remaining ~165 worker messages per second were reported to be ThreadUpdater ticks rather than culling work. This PR only changes which model a tick starts from and what a stopped-early sweep reports; it does not change the tick rate.
