### PR TITLE
perf(FragmentsModels): hierarchical frustum culling via the existing spatial lookup

### DIFF
--- a/packages/fragments/src/FragmentsModels/src/bounding-boxes/virtual-box-collider.ts
+++ b/packages/fragments/src/FragmentsModels/src/bounding-boxes/virtual-box-collider.ts
@@ -36,24 +36,34 @@ export class VirtualBoxCollider {
     return this.collide(onCollide, onIncludes, onSeen, fullyIncluded);
   }
 
+  /**
+   * Marks every point whose box does NOT touch the given frustum (plus
+   * optional clipping planes) with 1 in `mask`, and every candidate
+   * with 0. Same traversal and plane semantics as {@link frustumCollide},
+   * but writes into a caller-owned mask instead of allocating a result
+   * array — the culling hot path calls this on every view change, and
+   * with everything on screen a result array would hold every sample.
+   */
+  frustumFillOutsideMask(
+    bounds: THREE.Plane[],
+    frustum: THREE.Frustum,
+    mask: Uint8Array,
+  ) {
+    mask.fill(1);
+    const planes = this.getFrustumPlanes(frustum, bounds);
+    const onCollide = this.getFrustumOnCollide(planes);
+    const onIncludes = this.getFrustumOnIncludes(planes);
+    const onSeen = this.newDefaultCallback(true);
+    this.traverse(onCollide, onIncludes, onSeen, (data) => {
+      mask[data] = 0;
+    });
+  }
+
   rayCollide(bounds: THREE.Plane[], ray: THREE.Ray): number[] {
     const onCollide = this.getRayOnCollide(ray);
     const onIncludes = this.newDefaultCallback(false);
     const onSeen = this.getRayOnSeen(bounds);
     return this.collide(onCollide, onIncludes, onSeen);
-  }
-
-  private addPoint(
-    fullyIncluded: boolean,
-    result: number[],
-    currentPosition: number,
-    includes: boolean,
-  ) {
-    if (!fullyIncluded) {
-      result.push(this.getPointData(currentPosition));
-    } else if (includes) {
-      result.push(this.getPointData(currentPosition));
-    }
   }
 
   private getPointData(position: number): number {
@@ -107,8 +117,26 @@ export class VirtualBoxCollider {
     onSeen: BoxEvent,
     fullyIncluded = false,
   ): number[] {
-    const pointAmount = this._data.points.length;
     const result: number[] = [];
+    this.traverse(onCollide, onIncludes, onSeen, (data, includes) => {
+      if (!fullyIncluded || includes) {
+        result.push(data);
+      }
+    });
+    return result;
+  }
+
+  // Shared hierarchy walk: groups whose box misses the query are skipped
+  // wholesale, fully-included groups collect their leaves without further
+  // box tests, and each surviving leaf is handed to `onLeaf` together
+  // with whether it sits in a fully-included group.
+  private traverse(
+    onCollide: BoxEvent,
+    onIncludes: BoxEvent,
+    onSeen: BoxEvent,
+    onLeaf: (data: number, includes: boolean) => void,
+  ) {
+    const pointAmount = this._data.points.length;
     let currentPosition = 0;
 
     const addAllPoints = (bound: THREE.Box3, includes: boolean) => {
@@ -116,11 +144,7 @@ export class VirtualBoxCollider {
       for (; currentPosition < finalPosition; currentPosition++) {
         const isPoint = this.isPoint(currentPosition);
         if (isPoint && onSeen(bound)) {
-          if (!fullyIncluded) {
-            this.savePoint(currentPosition, result);
-          } else if (includes) {
-            this.savePoint(currentPosition, result);
-          }
+          onLeaf(this.getPointData(currentPosition), includes);
         }
       }
     };
@@ -132,7 +156,7 @@ export class VirtualBoxCollider {
       const collides = includes || onCollide(bound);
 
       if (isPoint && collides && onSeen(bound)) {
-        this.addPoint(fullyIncluded, result, currentPosition, includes);
+        onLeaf(this.getPointData(currentPosition), includes);
       }
 
       if (collides || isPoint) {
@@ -148,8 +172,6 @@ export class VirtualBoxCollider {
     while (currentPosition < pointAmount) {
       processCollisions();
     }
-
-    return result;
   }
 
   private getFrustumOnIncludes(planes: THREE.Plane[]) {
@@ -177,8 +199,4 @@ export class VirtualBoxCollider {
     return planes;
   }
 
-  private savePoint(position: number, result: number[]) {
-    const point = this.getPoint(position);
-    result.push(point.data);
-  }
 }

--- a/packages/fragments/src/FragmentsModels/src/bounding-boxes/virtual-box-structure.ts
+++ b/packages/fragments/src/FragmentsModels/src/bounding-boxes/virtual-box-structure.ts
@@ -44,6 +44,20 @@ export class VirtualBoxStructure {
     return this._collider.frustumCollide(bounds, frustum, fullyIncluded);
   }
 
+  /**
+   * Fills `mask` with 1 for every sample whose box is fully outside the
+   * frustum (plus optional clipping planes) and 0 for every candidate.
+   * Allocation-free variant of {@link collideFrustum} for the per-view
+   * culling pass.
+   */
+  fillOutsideFrustumMask(
+    bounds: THREE.Plane[],
+    frustum: THREE.Frustum,
+    mask: Uint8Array,
+  ) {
+    this._collider.frustumFillOutsideMask(bounds, frustum, mask);
+  }
+
   collideRay(bounds: THREE.Plane[], beam: THREE.Ray): number[] {
     return this._collider.rayCollide(bounds, beam);
   }

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-tiles-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-tiles-controller.ts
@@ -136,6 +136,17 @@ export class VirtualTilesController {
   private _changedSamples = 0;
   private _virtualView: any;
 
+  /**
+   * Per-sample frustum verdict from the spatial hierarchy, refreshed on
+   * every real view change: 1 = the sample's box is provably outside
+   * the frustum/clipping planes (skip all per-sample plane math in
+   * {@link fetchLodLevel}), 0 = candidate (run the exact per-sample
+   * test as before, so the final classification is unchanged). All
+   * zeroes when no view or lookup exists — the pass then behaves
+   * exactly like the flat version.
+   */
+  private _outsideMask: Uint8Array;
+
   private _lodMode = LodMode.DEFAULT;
 
   constructor(data: VirtualTileData) {
@@ -155,6 +166,7 @@ export class VirtualTilesController {
     this._sampleLodClass = new Uint8Array(this._sampleAmount);
     this._sampleLodState = new Uint8Array(this._sampleAmount);
     this._sampleLodSize = new Float32Array(this._sampleAmount);
+    this._outsideMask = new Uint8Array(this._sampleAmount);
     this._tileDimension = this.computeTileSize();
     this._tileBySample = new Array(this._sampleAmount);
     this._lodBySample = new Array(this._sampleAmount);
@@ -215,6 +227,26 @@ export class VirtualTilesController {
     this.updateOrientationIfNeeded();
     this.updatePositionIfNeeded();
     this.setupViewPlanes();
+    this.updateOutsideMask();
+  }
+
+  /**
+   * Rebuilds {@link _outsideMask} from the spatial hierarchy for the
+   * current view. One hierarchy walk per view change replaces the
+   * per-sample plane tests for everything that is provably outside —
+   * with a zoomed-in camera that is typically most of the model. Falls
+   * back to all-candidates (no skipping) when the model has no lookup
+   * (empty model) or no view yet.
+   */
+  private updateOutsideMask() {
+    const lookup = this._boxes.lookup;
+    const frustum = this._virtualView?.cameraFrustum;
+    if (!lookup || !frustum) {
+      this._outsideMask.fill(0);
+      return;
+    }
+    const clipping = this._virtualView.clippingPlanes ?? [];
+    lookup.fillOutsideFrustumMask(clipping, frustum, this._outsideMask);
   }
 
   updateVirtualMeshes(itemIds: number[]) {
@@ -924,6 +956,14 @@ export class VirtualTilesController {
         return CurrentLod.INVISIBLE;
       }
       return CurrentLod.GEOMETRY;
+    }
+
+    // Hierarchy verdict first: samples in branches that miss the view
+    // entirely skip the per-sample plane math. Candidates (mask 0) go
+    // through the exact same test as before, so the classification any
+    // sample ends up with is unchanged.
+    if (this._outsideMask[sample]) {
+      return CurrentLod.INVISIBLE;
     }
 
     const item = this._boxes.get(sample);


### PR DESCRIPTION
Closes #280.

The per-view cull pass tested every sample's box against the frustum and clipping planes individually — a flat O(samples) sweep per model on every real view change, even when most of the model is far outside the view (the normal case for interior navigation). The spatial hierarchy that already exists for raycasting (`VirtualBoxStructure`) now feeds the same pass:

- `VirtualBoxCollider` gains an allocation-free mask traversal (`frustumFillOutsideMask`) sharing the exact walk and plane semantics of `frustumCollide`; `collide()` is refactored onto the shared traversal so the two cannot drift apart.
- `VirtualTilesController` rebuilds a per-sample outside-mask on every real view change. Samples in branches that provably miss the view skip the per-sample plane math; **every candidate still runs the exact original test**, so the final classification of any sample is unchanged.
- Fully-included branches collect their leaves without per-leaf box tests, so the whole-model-in-view case stays fast too.

## Measurements

13 real project models (`.frag`, converted from IFC; headless Chromium): interior look-around CPU −14 %, settle after orbiting 44 ms → 23 ms, idle and whole-building orbit unchanged.

8 models on a Radeon 780M, exterior poses only (which is the case this optimisation helps least, everything is in view): neutral within noise, draw calls identical, tile batches per 5 s orbit 680 → 725. Verified identical rendered triangle counts across fixed camera poses, within the pre-existing run-to-run noise of the LRU mesh cache; a same-build control run shows the same noise.

Screenshot diff over six fixed poses: 0.000 % on five, 0.07 % on one — one façade strip where two coplanar surfaces z-fight and the tile that arrives first wins, so any change in tile arrival order flips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rtNQqhSQRM2t6E98DESNE