### PR TITLE
fix: setSample() passes highlight state instead of visibility to updateTile()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+* `setSample()` passed `high === 0` (a highlight-derived value, true for almost every non-highlighted sample) as the `visible` argument to `updateTile()`, instead of the method's own `vis` parameter (the real value `VisibilityHelper.setVisible()`/`toggleVisible()` compute from `model.itemConfig`). On models where the affected samples' LOD state doesn't otherwise change on the same tick, this means a `setVisible()`/`toggleVisible()` call updates the model's own visibility state (`getVisible()` reflects it correctly) without ever updating the corresponding tile's rendered geometry - most reliably observed on large (10k+ item) models, where the correct LOD-driven `updateVisible()` path is less frequently re-entered for the same samples than on small models.
+
 ### ⚠ BREAKING CHANGES
 
 * `split`/`extract`: have become `async`, have changed signature (including return types) and are scoped under `IfcSplitter`, exposed events (`onProgress`, `onSplitsResolved`, `onExtractWarning`) instead of console logs.

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-tiles-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-tiles-controller.ts
@@ -802,7 +802,7 @@ export class VirtualTilesController {
     const tileIds = this.getTileIds(id, lod);
     if (tileIds === undefined) return;
     MiscHelper.forEach(tileIds, (tileId) => {
-      this.updateTile(tileId, id, high, high === 0);
+      this.updateTile(tileId, id, high, vis);
     });
   }
 


### PR DESCRIPTION
Fixes #287.

## What

`VirtualTilesController.setSample()` computes the correct `vis` (the real visibility value `VisibilityHelper.setVisible()`/`toggleVisible()` set via `model.itemConfig`) and correctly stores it (`this._samples.setVisible(id, vis)`), but then calls:

```ts
this.updateTile(tileId, id, high, high === 0);
```

passing `high === 0` (true for almost every non-highlighted sample) as `updateTile`'s `visible` argument instead of `vis`. That argument flows into `updateTileData(tile, sample, visible, highlight)`, which writes `tile.visibilities.update(id, visible)` - the buffer that actually controls whether the tile renders that sample. So the tile's rendered visibility ends up effectively decoupled from the real value `setVisible()`/`toggleVisible()` set.

## Why it's hard to notice on small models

This exact line is only reached when a sample's LOD classification is unchanged since the last tick (the `updateSampleIfSeen()`/`current === past` fast path). Small models finish a full `update()` cycle in one tick, so the "LOD just changed" path (`updateVisible()`, which handles the immediate transition correctly before ever reaching `setSample`) dominates and the bug rarely surfaces. On a large model most ticks re-enter already-classified samples, so the buggy path dominates instead, and the effect becomes reliably reproducible - see #287 for the full repro and confirmation (before/after, verified in both directions on a real 12,338-item / 18,382-sample model, using a locally-built worker so there's no ambiguity about which build was under test).

## Fix

One line: pass `vis` instead of `high === 0`.

## Test plan

- [x] Reproduced with the original code: `getVisible()` correctly reflects a `setVisible()`/`toggleVisible()` call, the render never updates, on a real 12k-item / 18k-sample model, even after 100 repeated `fragments.update(true)` calls.
- [x] Rebuilt the worker with the fix, pointed a local copy of the `VisibilityOperations` example at it (`packages/fragments/dist/Worker/worker.mjs` instead of the CDN URL from `FragmentsModels.getWorker()`, to make sure the fixed build was actually under test) and confirmed the SAME model now toggles correctly and reproducibly, both directions (show → hide → show), on the very first call.
- [ ] I did not run `yarn test` / add an automated example per CONTRIBUTING.md's "Fixing a bug" section, since the bug only reproduces reliably at real-file scale (10k+ items) - happy to add a synthetic large-model example/test if that's the preferred way to land this; wanted to get the root cause and confirmed fix up first given how deep it was to track down.