### PR TITLE
fix: reuse preserved highlight material definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+* Reuse identical preserved highlight materials across items and repeated updates, while keeping depth, transparency and inheritance settings distinct.
+
 ### ⚠ BREAKING CHANGES
 
 * `split`/`extract`: have become `async`, have changed signature (including return types) and are scoped under `IfcSplitter`, exposed events (`onProgress`, `onSplitsResolved`, `onExtractWarning`) instead of console logs.

--- a/packages/fragments/src/FragmentsModels/src/utils/geometry/material-utils.ts
+++ b/packages/fragments/src/FragmentsModels/src/utils/geometry/material-utils.ts
@@ -1,49 +1,26 @@
-import * as THREE from "three";
 import { RenderedFaces } from "../../../../Schema";
 import { MaterialDefinition } from "../../model/model-types";
 
 export class MaterialUtils {
   static isSame(a: MaterialDefinition, b: MaterialDefinition) {
-    const isSameColor = this.checkSameColor(a.color, b.color);
-    const isSameOpacity = this.checkSame(a.opacity, b.opacity, 1.0);
-    const facesA = a.renderedFaces;
-    const facesB = b.renderedFaces;
-    const isSameFaces = this.checkSame(facesA, facesB, RenderedFaces.ONE);
-    return isSameColor && isSameOpacity && isSameFaces;
+    return this.getKey(a) === this.getKey(b);
   }
 
-  private static checkSame(a: any, b: any, fallback: any): boolean {
-    if (a === b) {
-      return true;
+  /** Returns a stable key including rendering and inheritance semantics. */
+  static getKey(material: MaterialDefinition) {
+    const { color, _explicitProps, ...properties } = material;
+    // Missing properties on preserved highlights inherit from the base material.
+    // They must stay distinct from explicitly supplied default values.
+    if (!material.preserveOriginalMaterial) {
+      properties.opacity ??= 1;
+      properties.renderedFaces ??= RenderedFaces.ONE;
     }
-
-    if (a === fallback && b === undefined) {
-      return true;
-    }
-
-    if (a === undefined && b === fallback) {
-      return true;
-    }
-
-    return false;
-  }
-
-  private static checkSameColor(a: THREE.Color, b: THREE.Color) {
-    if (a === b) {
-      return true;
-    }
-
-    if (a === undefined || b === undefined) {
-      return false;
-    }
-
-    const { r: ar, g: ag, b: ab } = a;
-    const { r: br, g: bg, b: bb } = b;
-
-    if (ar === br && ag === bg && ab === bb) {
-      return true;
-    }
-
-    return false;
+    return JSON.stringify([
+      color && [color.r, color.g, color.b, color.isColor === true],
+      [...new Set(_explicitProps ?? [])].sort(),
+      Object.entries(properties)
+        .filter(([, value]) => value !== undefined)
+        .sort(([a], [b]) => a.localeCompare(b)),
+    ]);
   }
 }

--- a/packages/fragments/src/FragmentsModels/src/utils/misc/crc.ts
+++ b/packages/fragments/src/FragmentsModels/src/utils/misc/crc.ts
@@ -4,6 +4,7 @@
 import { MaterialDefinition } from "../../model/model-types";
 import { CRCData } from "./crc-data";
 import { IntHelper } from "./int-helper";
+import { MaterialUtils } from "../geometry/material-utils";
 
 // src: https://stackoverflow.com/questions/27939882/fast-crc-algorithm
 
@@ -44,7 +45,7 @@ export class CRC {
     this.reset();
     this.compute(modelId);
     this.compute(objectClass);
-    this.compute(materialDefinition);
+    this.compute(MaterialUtils.getKey(materialDefinition));
     this.compute(currentLod);
     this.compute(templateId !== undefined);
   }

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-material-controller.test.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-material-controller.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import * as THREE from "three";
+import { MaterialDefinition } from "../../model/model-types";
+import { MaterialManager } from "../../model/material-manager";
+import { VirtualMaterialController } from "./virtual-material-controller";
+
+function harness() {
+  const definitions: MaterialDefinition[] = [];
+  const renderer = new MaterialManager();
+  const controller = new VirtualMaterialController("model", (event) => {
+    definitions.push(...event.materialDefinitions);
+    renderer.addDefinitions("model", event.materialDefinitions);
+  });
+  return { controller, definitions, renderer };
+}
+
+const original = (opacity = 1): MaterialDefinition => ({
+  color: new THREE.Color(0.8, 0.2, 0.1),
+  opacity,
+  transparent: opacity < 1,
+  renderedFaces: 0,
+});
+
+const opacityOverride = (opacity: number) =>
+  ({
+    opacity,
+    transparent: opacity < 1,
+    preserveOriginalMaterial: true,
+    _explicitProps: ["opacity", "transparent"],
+  }) as MaterialDefinition;
+
+describe("preserved material definitions", () => {
+  test("reuses identical overrides across items and repeated slider values", () => {
+    const { controller, definitions } = harness();
+    controller.transfer([original()]);
+    const first = controller.transfer([opacityOverride(0.25)])[0];
+    controller.transfer([opacityOverride(0.5)]);
+    const ids = controller.transfer(
+      Array.from({ length: 1000 }, () => opacityOverride(0.25)),
+    );
+    expect(new Set(ids)).toEqual(new Set([first]));
+    expect(definitions).toHaveLength(3);
+  });
+
+  test("a reused color override preserves each original opacity", () => {
+    const { controller, renderer } = harness();
+    const bases = controller.transfer([original(1), original(0.2)]);
+    const override = {
+      color: new THREE.Color(0, 1, 0),
+      preserveOriginalMaterial: true,
+      _explicitProps: ["color"],
+    } as MaterialDefinition;
+    const [a, b] = controller.transfer([override, { ...override }]);
+    expect(a).toBe(b);
+    expect(renderer.getHighlightProps(a, bases[0], "model")?.opacity).toBe(1);
+    expect(renderer.getHighlightProps(b, bases[1], "model")?.opacity).toBe(0.2);
+  });
+
+  test("does not alias different depth, transparency, custom ID or inheritance semantics", () => {
+    const { controller } = harness();
+    const base = original();
+    const variants = [
+      base,
+      { ...base, depthWrite: false },
+      { ...base, depthTest: false },
+      { ...base, transparent: true },
+      { ...base, customId: "selection" },
+      { ...base, localId: 12 },
+      { ...base, preserveOriginalMaterial: true, _explicitProps: ["color"] },
+      { ...base, preserveOriginalMaterial: true, _explicitProps: ["opacity"] },
+    ];
+    expect(new Set(controller.transfer(variants)).size).toBe(variants.length);
+  });
+
+  test("explicit property order does not create a new override", () => {
+    const { controller } = harness();
+    const a = opacityOverride(0.4);
+    const b = { ...a, _explicitProps: ["transparent", "opacity", "opacity"] };
+    const ids = controller.transfer([a, b]);
+    expect(ids[0]).toBe(ids[1]);
+  });
+});

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-material-controller.test.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-material-controller.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 import * as THREE from "three";
-import { MaterialDefinition } from "../../model/model-types";
+import {
+  MaterialDefinition,
+  ObjectClass,
+  CurrentLod,
+} from "../../model/model-types";
 import { MaterialManager } from "../../model/material-manager";
 import { VirtualMaterialController } from "./virtual-material-controller";
 
@@ -30,6 +34,22 @@ const opacityOverride = (opacity: number) =>
   }) as MaterialDefinition;
 
 describe("preserved material definitions", () => {
+  test("rendered materials distinguish named depth properties, independently of insertion order", () => {
+    const { renderer } = harness();
+    const request = {
+      modelId: "model",
+      objectClass: ObjectClass.SHELL,
+      currentLod: CurrentLod.GEOMETRY,
+    };
+    const noWrite = renderer.get({ ...original(), depthWrite: false }, request);
+    const noTest = renderer.get({ ...original(), depthTest: false }, request);
+    expect(noWrite).not.toBe(noTest);
+    expect(noTest.depthWrite).toBe(true);
+    expect(noTest.depthTest).toBe(false);
+    expect(renderer.get({ depthWrite: false, ...original() }, request)).toBe(
+      noWrite,
+    );
+  });
   test("reuses identical overrides across items and repeated slider values", () => {
     const { controller, definitions } = harness();
     controller.transfer([original()]);

--- a/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-material-controller.ts
+++ b/packages/fragments/src/FragmentsModels/src/virtual-model/virtual-controllers/virtual-material-controller.ts
@@ -11,6 +11,7 @@ type VirtualMaterialTransfer = (data: any, trans?: any[]) => void;
 export class VirtualMaterialController {
   private readonly _modelId: string;
   private readonly _list: MaterialDefinition[] = [];
+  private readonly _idsByDefinition = new Map<string, number>();
   private readonly _onTransfer: VirtualMaterialTransfer;
 
   constructor(modelId: string, onTransfer: VirtualMaterialTransfer) {
@@ -64,36 +65,19 @@ export class VirtualMaterialController {
     return result;
   }
 
-  private checkMaterialExists(material: MaterialDefinition, ids: number[]) {
-    // Don't deduplicate materials with preserveOriginalMaterial flag,
-    // as they need to preserve original material properties (like opacity)
-    // which may differ from existing materials with the same color
-    if (material.preserveOriginalMaterial) {
-      return false;
-    }
-    const count = this._list.length;
-    for (let i = 0; i < count; i++) {
-      const current = this._list[i];
-      const isSame = MaterialUtils.isSame(material, current);
-      if (isSame) {
-        ids.push(i);
-        return true;
-      }
-    }
-    return false;
-  }
-
   private deduplicateMaterials(materialDefinition: MaterialDefinition[]) {
     const ids = [] as number[];
     const materialDefinitions = [] as MaterialDefinition[];
     for (const material of materialDefinition) {
-      const exists = this.checkMaterialExists(material, ids);
-      if (!exists) {
+      const key = MaterialUtils.getKey(material);
+      let id = this._idsByDefinition.get(key);
+      if (id === undefined) {
+        id = this._list.length;
         this._list.push(material);
+        this._idsByDefinition.set(key, id);
         materialDefinitions.push(material);
-        const currentId = this._list.length - 1;
-        ids.push(currentId);
       }
+      ids.push(id);
     }
     return { materialDefinitions, ids };
   }


### PR DESCRIPTION
Repeated preserved highlights currently allocate an identical material definition for every affected item and update. Reuse definitions by a stable key that includes rendering settings and explicit inheritance properties. The same override can be shared while retaining each item's original opacity.

The renderer uses the same named-property identity: `depthWrite: false` and `depthTest: false` no longer alias, and object insertion order does not create another material.

Validation:
- Regression tests failed on the original implementation, then passed after the fix; 26 focused tests pass across material definitions, view handling and edit request indexing.
- TypeScript and library/worker build pass.
- Native worker check on a small generated fixture: 10 geometric IDs, 300 updates alternating two opacity settings, 601 transferred definitions before versus 3 after. This establishes reuse for repeated settings; it does not establish faster runtime or lower GPU memory. Distinct settings still retain distinct definitions.

No file format or public method signature change. Generated worker bundles are intentionally excluded from the source diff.
