### PR TITLE
fix: settle update fences when the last model is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+* Settle forced updates when the scene is empty or the last model is removed, without waiting for a worker FINISH that can no longer arrive.
+
 ### ⚠ BREAKING CHANGES
 
 * `split`/`extract`: have become `async`, have changed signature (including return types) and are scoped under `IfcSplitter`, exposed events (`onProgress`, `onSplitsResolved`, `onExtractWarning`) instead of console logs.

--- a/packages/fragments/src/FragmentsModels/src/model/mesh-manager-fence.test.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/mesh-manager-fence.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { MeshManager } from "./mesh-manager";
+import { FragmentsModel } from "./fragments-model";
+import { TileRequestClass } from "./model-types";
+import { MultithreadingHelper } from "../multithreading/multithreading-helper";
+
+function model() {
+  return { _finishProcessing() {} } as FragmentsModel;
+}
+
+describe("update fences when models are removed", () => {
+  test("an empty manager does not await a FINISH for previous requests", async () => {
+    const meshes = new MeshManager(() => {});
+    MultithreadingHelper.nextSeq();
+    await meshes.forceUpdateFinish();
+  }, 500);
+
+  test.each(["delete", "clear"] as const)(
+    "%s releases all pending fences when no model remains",
+    async (operation) => {
+      const meshes = new MeshManager(() => {});
+      meshes.list.set("a", model());
+      MultithreadingHelper.nextSeq();
+      const first = meshes.forceUpdateFinish();
+      MultithreadingHelper.nextSeq();
+      const second = meshes.forceUpdateFinish();
+      if (operation === "delete") meshes.list.delete("a");
+      else meshes.list.clear();
+      await Promise.all([first, second]);
+    },
+    500,
+  );
+
+  test("removing one of two models still waits for the remaining model's FINISH", async () => {
+    const meshes = new MeshManager(() => {});
+    meshes.list.set("a", model());
+    meshes.list.set("b", model());
+    const seq = MultithreadingHelper.nextSeq();
+    let finished = false;
+    const pending = meshes.forceUpdateFinish().then(() => {
+      finished = true;
+    });
+    meshes.list.delete("a");
+    await Promise.resolve();
+    expect(finished).toBe(false);
+    meshes.requests.add([
+      { modelId: "b", tileRequestClass: TileRequestClass.FINISH, seq },
+    ]);
+    await pending;
+    expect(finished).toBe(true);
+  });
+
+  test("a model loaded after an empty scene still requires its own FINISH", async () => {
+    const meshes = new MeshManager(() => {});
+    MultithreadingHelper.nextSeq();
+    await meshes.forceUpdateFinish();
+    meshes.list.set("new", model());
+    const seq = MultithreadingHelper.nextSeq();
+    let finished = false;
+    const pending = meshes.forceUpdateFinish().then(() => {
+      finished = true;
+    });
+    await Promise.resolve();
+    expect(finished).toBe(false);
+    meshes.requests.add([
+      { modelId: "new", tileRequestClass: TileRequestClass.FINISH, seq },
+    ]);
+    await pending;
+    expect(finished).toBe(true);
+  }, 500);
+});

--- a/packages/fragments/src/FragmentsModels/src/model/mesh-manager.ts
+++ b/packages/fragments/src/FragmentsModels/src/model/mesh-manager.ts
@@ -49,6 +49,8 @@ export class MeshManager {
   constructor(onUpdate: () => void) {
     this._onUpdate = onUpdate;
     this.requests.onFinish = (seq) => this.handleFinish(seq);
+    this.list.onItemDeleted.add(() => this.finishEmptyScene());
+    this.list.onCleared.add(() => this.finishEmptyScene());
   }
 
   /**
@@ -73,13 +75,24 @@ export class MeshManager {
     // No outbound RPCs have been issued yet, or everything we've sent
     // has already settled — nothing to wait for. Drain whatever's in
     // the queue (may be empty) and return.
-    if (this._lastSettledSeq >= targetSeq) {
+    if (this.list.size === 0 || this._lastSettledSeq >= targetSeq) {
       this.drainAll();
       return;
     }
     await new Promise<void>((resolve) => {
       this._fenceWaiters.push({ targetSeq, resolve });
     });
+  }
+
+  private finishEmptyScene() {
+    if (this.list.size !== 0) return;
+    // Removed models cannot produce further visible tile updates. Do not
+    // advance the settled sequence: subsequently loaded models still need
+    // their own worker FINISH.
+    this.drainAll();
+    const waiters = this._fenceWaiters;
+    this._fenceWaiters = [];
+    for (const waiter of waiters) waiter.resolve();
   }
 
   /**


### PR DESCRIPTION
`FragmentsModels.update(true)` can wait forever after the final model is removed: its fence snapshots an outstanding sequence, but there is no model left to emit the FINISH it needs.

An empty MeshManager now drains obsolete requests and completes immediately. Removing or clearing the last model also releases already-pending waiters. This does not advance the settled sequence, so another loaded model still needs its own FINISH.

Validation: four regression scenarios timed out before the fix; 21 focused tests pass after it, including deleting one of two models and loading another model after the empty state. TypeScript passes. No worker protocol, timer, polling or public API changes.
